### PR TITLE
Don't try to Auth when Connection fail

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -219,6 +219,8 @@ namespace OBSWebsocketDotNet
             };
             WSConnection.Connect();
 
+            if (!WSConnection.IsAlive) return;
+
             OBSAuthInfo authInfo = GetAuthInfo();
 
             if (authInfo.AuthRequired)


### PR DESCRIPTION
If websocket connection fail, do not try to Auth.

May be related to #9