### PR TITLE
Revamp of code, add all currently documented functionality

### DIFF
--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Windows.Forms;
 using OBSWebsocketDotNet;
+using OBSWebsocketDotNet.Types;
 
 namespace TestClient
 {

--- a/obs-websocket-dotnet-tests/UnitTest_Types.cs
+++ b/obs-websocket-dotnet-tests/UnitTest_Types.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet.Types;
 
 namespace OBSWebsocketDotNet.Tests
 {

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -177,7 +177,7 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Audio mixer routing changed on a source
         /// </summary>
-        public event SourceAudioMixerChangedCallback SourceAudioMixersChanged;
+        public event SourceAudioMixersChangedCallback SourceAudioMixersChanged;
 
         /// <summary>
         /// The audio sync offset of a source has changed
@@ -322,6 +322,8 @@ namespace OBSWebsocketDotNet
                 tcs.TrySetCanceled();
             }
         }
+
+
 
         // This callback handles incoming JSON messages and determines if it's
         // a request response or an event ("Update" in obs-websocket terminology)
@@ -635,7 +637,7 @@ namespace OBSWebsocketDotNet
                     break;
                 case "SceneItemTransformChanged":
                     if (SceneItemTransformChanged != null)
-                        SceneItemTransformChanged(this, new SceneItemTransform((JObject)body["transform"])); //requires custom object
+                        SceneItemTransformChanged(this, new SceneItemTransformInfo(body)); //requires custom object
                     break;
                 case "SourceAudioMixersChanged":
                     if (SourceAudioMixersChanged != null)
@@ -682,9 +684,10 @@ namespace OBSWebsocketDotNet
                         SourceFiltersReordered(this, (string)body["sourceName"], filters);
                     break;
                 default:
-                    Console.WriteLine("S-----------" + eventType + "-------------");
+                    var header = "-----------" + eventType + "-------------";
+                    Console.WriteLine(header);
                     Console.WriteLine(body);
-                    Console.WriteLine("E------------------------");
+                    Console.WriteLine("".PadLeft(header.Length,'-'));
                     break;
             }
         }

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -29,6 +29,8 @@ using System.Text;
 using WebSocketSharp;
 using Newtonsoft.Json.Linq;
 using System.Threading.Tasks;
+using OBSWebsocketDotNet.Types;
+using Newtonsoft.Json;
 
 namespace OBSWebsocketDotNet
 {
@@ -149,6 +151,79 @@ namespace OBSWebsocketDotNet
         /// Triggered when disconnected from an obs-websocket server
         /// </summary>
         public event EventHandler Disconnected;
+
+        /// <summary>
+        /// Emitted every 2 seconds after enabling it by calling SetHeartbeat
+        /// </summary>
+        public event HeartBeatCallback Heartbeat;
+
+
+
+        /// <summary>
+        /// A scene item is deselected
+        /// </summary>
+        public event SceneItemDeselectedCallback SceneItemDeselected;
+
+        /// <summary>
+        /// A scene item is selected
+        /// </summary>
+        public event SceneItemSelectedCallback SceneItemSelected;
+
+        /// <summary>
+        /// A scene item transform has changed
+        /// </summary>
+        public event SceneItemTransformCallback SceneItemTransformChanged;
+
+        /// <summary>
+        /// Audio mixer routing changed on a source
+        /// </summary>
+        public event SourceAudioMixerChangedCallback SourceAudioMixersChanged;
+
+        /// <summary>
+        /// The audio sync offset of a source has changed
+        /// </summary>
+        public event SourceAudioSyncOffsetCallback SourceAudioSyncOffsetChanged;
+
+        /// <summary>
+        /// A source has been created. A source can be an input, a scene or a transition.
+        /// </summary>
+        public event SourceCreatedCallback SourceCreated;
+
+        /// <summary>
+        /// A source has been destroyed/removed. A source can be an input, a scene or a transition.
+        /// </summary>
+        public event SourceDestroyedCallback SourceDestroyed;
+
+        /// <summary>
+        /// A filter was added to a source
+        /// </summary>
+        public event SourceFilterAddedCallback SourceFilterAdded;
+
+        /// <summary>
+        /// A filter was removed from a source
+        /// </summary>
+        public event SourceFilterRemovedCallback SourceFilterRemoved;
+
+        /// <summary>
+        /// Filters in a source have been reordered
+        /// </summary>
+        public event SourceFiltersReorderedCallback SourceFiltersReordered;
+
+        /// <summary>
+        /// A source has been muted or unmuted
+        /// </summary>
+        public event SourceMuteStateChangedCallback SourceMuteStateChanged;
+
+        /// <summary>
+        /// A source has been renamed
+        /// </summary>
+        public event SourceRenamedCallback SourceRenamed;
+
+        /// <summary>
+        /// The volume of a source has changed
+        /// </summary>
+        public event SourceVolumeChangedCallback SourceVolumeChanged;
+
         #endregion
 
         /// <summary>
@@ -218,6 +293,9 @@ namespace OBSWebsocketDotNet
                     Disconnected(this, e);
             };
             WSConnection.Connect();
+
+            if (!WSConnection.IsAlive)
+                return;
 
             OBSAuthInfo authInfo = GetAuthInfo();
 
@@ -541,6 +619,72 @@ namespace OBSWebsocketDotNet
                 case "Exiting":
                     if (OBSExit != null)
                         OBSExit(this, EventArgs.Empty);
+                    break;
+
+                case "Heartbeat":
+                    if (Heartbeat != null)
+                        Heartbeat(this, new Heartbeat(body));
+                    break;
+                case "SceneItemDeselected":
+                    if (SceneItemDeselected != null)
+                        SceneItemDeselected(this, (string)body["scene-name"], (string)body["item-name"], (string)body["item-id"]);
+                    break;
+                case "SceneItemSelected":
+                    if (SceneItemSelected != null)
+                        SceneItemSelected(this, (string)body["scene-name"], (string)body["item-name"], (string)body["item-id"]);
+                    break;
+                case "SceneItemTransformChanged":
+                    if (SceneItemTransformChanged != null)
+                        SceneItemTransformChanged(this, new SceneItemTransform((JObject)body["transform"])); //requires custom object
+                    break;
+                case "SourceAudioMixersChanged":
+                    if (SourceAudioMixersChanged != null)
+                        SourceAudioMixersChanged(this, new AudioMixersChangedInfo(body)); //requires custom object
+                    break;
+                case "SourceAudioSyncOffsetChanged":
+                    if (SourceAudioSyncOffsetChanged != null)
+                        SourceAudioSyncOffsetChanged(this, (string)body["sourceName"], (int)body["syncOffset"]);
+                    break;
+                case "SourceCreated":
+                    if (SourceCreated != null)
+                        SourceCreated(this, new SourceSettings(body));
+                    break;
+                case "SourceDestroyed":
+                    if (SourceDestroyed != null)
+                        SourceDestroyed(this, (string)body["sourceName"], (string)body["sourceType"], (string)body["sourceKind"]);
+                    break;
+                case "SourceRenamed":
+                    if (SourceRenamed != null)
+                        SourceRenamed(this, (string)body["newName"], (string)body["previousName"]);
+                    break;
+
+                case "SourceMuteStateChanged":
+                    if (SourceMuteStateChanged != null)
+                        SourceMuteStateChanged(this, (string)body["sourceName"], (bool)body["muted"]);
+                    break;
+                case "SourceVolumeChanged":
+                    if (SourceVolumeChanged != null)
+                        SourceVolumeChanged(this, (string)body["sourceName"], (float)body["volume"]);
+                    break;
+                case "SourceFilterAdded":
+                    if (SourceFilterAdded != null)
+                        SourceFilterAdded(this, (string)body["sourceName"], (string)body["filterName"], (string)body["filterType"], (JObject)body["filterSettings"]);
+                    break;
+                case "SourceFilterRemoved":
+                    if (SourceFilterRemoved != null)
+                        SourceFilterRemoved(this, (string)body["sourceName"], (string)body["filterName"]);
+                    break;
+                case "SourceFiltersReordered":
+                    List<FilterReorderItem> filters = new List<FilterReorderItem>();
+                    JsonConvert.PopulateObject(body["filters"].ToString(), filters);
+
+                    if (SourceFiltersReordered != null)
+                        SourceFiltersReordered(this, (string)body["sourceName"], filters);
+                    break;
+                default:
+                    Console.WriteLine("S-----------" + eventType + "-------------");
+                    Console.WriteLine(body);
+                    Console.WriteLine("E------------------------");
                     break;
             }
         }

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -157,8 +157,6 @@ namespace OBSWebsocketDotNet
         /// </summary>
         public event HeartBeatCallback Heartbeat;
 
-
-
         /// <summary>
         /// A scene item is deselected
         /// </summary>
@@ -637,11 +635,11 @@ namespace OBSWebsocketDotNet
                     break;
                 case "SceneItemTransformChanged":
                     if (SceneItemTransformChanged != null)
-                        SceneItemTransformChanged(this, new SceneItemTransformInfo(body)); //requires custom object
+                        SceneItemTransformChanged(this, new SceneItemTransformInfo(body));
                     break;
                 case "SourceAudioMixersChanged":
                     if (SourceAudioMixersChanged != null)
-                        SourceAudioMixersChanged(this, new AudioMixersChangedInfo(body)); //requires custom object
+                        SourceAudioMixersChanged(this, new AudioMixersChangedInfo(body));
                     break;
                 case "SourceAudioSyncOffsetChanged":
                     if (SourceAudioSyncOffsetChanged != null)
@@ -683,12 +681,14 @@ namespace OBSWebsocketDotNet
                     if (SourceFiltersReordered != null)
                         SourceFiltersReordered(this, (string)body["sourceName"], filters);
                     break;
+                /*
                 default:
                     var header = "-----------" + eventType + "-------------";
                     Console.WriteLine(header);
                     Console.WriteLine(body);
                     Console.WriteLine("".PadLeft(header.Length,'-'));
                     break;
+                 */
             }
         }
 

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -36,6 +36,63 @@ namespace OBSWebsocketDotNet
     public partial class OBSWebsocket
     {
         /// <summary>
+        /// Get basic OBS video information
+        /// </summary>
+        public OBSVideoInfo GetVideoInfo()
+        {
+            JObject response = SendRequest("GetVideoInfo");
+            return JsonConvert.DeserializeObject<OBSVideoInfo>(response.ToString());
+        }
+
+        /// <summary>
+        /// At least embedPictureFormat or saveToFilePath must be specified.
+        /// Clients can specify width and height parameters to receive scaled pictures. Aspect ratio is preserved if only one of these two parameters is specified.
+        /// </summary>
+        /// <param name="sourceName"></param>
+        /// <param name="embedPictureFormat">Format of the Data URI encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)</param>
+        /// <param name="saveToFilePath">Full file path (file extension included) where the captured image is to be saved. Can be in a format different from pictureFormat. Can be a relative path.</param>
+        /// <param name="width">Screenshot width. Defaults to the source's base width.</param>
+        /// <param name="height">Screenshot height. Defaults to the source's base height.</param>
+        public SourceScreenshotResponse TakeSourceScreenshot(string sourceName, string embedPictureFormat = null, string saveToFilePath = null, int width = -1, int height = -1)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("sourceName", sourceName);
+            if (embedPictureFormat != null)
+            requestFields.Add("embedPictureFormat", embedPictureFormat);
+            if (saveToFilePath != null)
+                requestFields.Add("saveToFilePath", saveToFilePath);
+            if (width > -1)
+            requestFields.Add("height", width);
+            if (height > -1)
+                requestFields.Add("height", height);
+
+            var response = SendRequest("TakeSourceScreenshot", requestFields);
+            return JsonConvert.DeserializeObject<SourceScreenshotResponse>(response.ToString());
+        }
+
+        /// <summary>
+        /// At least embedPictureFormat or saveToFilePath must be specified.
+        /// Clients can specify width and height parameters to receive scaled pictures. Aspect ratio is preserved if only one of these two parameters is specified.
+        /// </summary>
+        /// <param name="sourceName"></param>
+        /// <param name="embedPictureFormat">Format of the Data URI encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)</param>
+        /// <param name="saveToFilePath">Full file path (file extension included) where the captured image is to be saved. Can be in a format different from pictureFormat. Can be a relative path.</param>
+        public SourceScreenshotResponse TakeSourceScreenshot(string sourceName, string embedPictureFormat = null, string saveToFilePath = null)
+        {
+            return TakeSourceScreenshot(sourceName, embedPictureFormat, saveToFilePath);
+        }
+
+        /// <summary>
+        /// At least embedPictureFormat or saveToFilePath must be specified.
+        /// Clients can specify width and height parameters to receive scaled pictures. Aspect ratio is preserved if only one of these two parameters is specified.
+        /// </summary>
+        /// <param name="sourceName"></param>
+        public SourceScreenshotResponse TakeSourceScreenshot(string sourceName)
+        {
+            return TakeSourceScreenshot(sourceName);
+        }
+
+        /// <summary>
         /// Get the current scene info along with its items
         /// </summary>
         /// <returns>An <see cref="OBSScene"/> object describing the current scene</returns>
@@ -58,6 +115,25 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Get the filename formatting string
+        /// </summary>
+        /// <returns>Current filename formatting string</returns>
+        public string GetFilenameFormatting()
+        {
+            JObject response = SendRequest("GetFilenameFormatting");
+            return (string)response["filename-formatting"];
+        }
+
+        /// <summary>
+        /// Get OBS stats (almost the same info as provided in OBS' stats window)
+        /// </summary>
+        public OBSStats GetStats()
+        {
+            JObject response = SendRequest("GetStats");
+            return JsonConvert.DeserializeObject<OBSStats>(response["stats"].ToString());
+        }
+
+        /// <summary>
         /// List every available scene
         /// </summary>
         /// <returns>A <see cref="List{OBSScene}" /> of <see cref="OBSScene"/> objects describing each scene</returns>
@@ -74,6 +150,50 @@ namespace OBSWebsocketDotNet
             }
 
             return scenes;
+        }
+
+        /// <summary>
+        /// Get a list of scenes in the currently active profile
+        /// </summary>
+        public GetSceneListInfo GetSceneList()
+        {
+            JObject response = SendRequest("GetSceneList");
+            return JsonConvert.DeserializeObject<GetSceneListInfo>(response.ToString());
+        }
+
+        /// <summary>
+        /// Changes the order of scene items in the requested scene
+        /// </summary>
+        /// <param name="sceneName">Name of the scene to reorder (defaults to current)</param>
+        /// <param name="sceneItems">List of items to reorder, only ID or Name required</param>
+        public void ReorderSceneItems(List<SceneItemStub> sceneItems, string sceneName = null)
+        {
+            var requestFields = new JObject();
+            if (sceneName != null)
+                requestFields.Add("scene", sceneName);
+
+            var items = JObject.Parse(JsonConvert.SerializeObject(sceneItems));
+            requestFields.Add("items", items);
+
+            SendRequest("ReorderSceneItems", requestFields);
+        }
+
+        /// <summary>
+        /// List all sources available in the running OBS instance
+        /// </summary>
+        public List<SourceInfo> GetSourcesList()
+        {
+            JObject response = SendRequest("GetSourcesList");
+            return JsonConvert.DeserializeObject<List<SourceInfo>>(response["sources"].ToString());
+        }
+
+        /// <summary>
+        /// List all sources available in the running OBS instance
+        /// </summary>
+        public List<SourceType> GetSourceTypesList()
+        {
+            JObject response = SendRequest("GetSourceTypesList");
+            return JsonConvert.DeserializeObject<List<SourceType>>(response["types"].ToString());
         }
 
         /// <summary>
@@ -95,18 +215,93 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Gets the scene specific properties of the specified source item. Coordinates are relative to the item's parent (the scene or group it belongs to).
+        /// </summary>
+        /// <param name="itemName">The name of the source</param>
+        /// <param name="sceneName">The name of the scene that the source item belongs to. Defaults to the current scene.</param>
+        public SceneItemProperties GetSceneItemProperties(string itemName, string sceneName = null)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("item", itemName);
+
+            if (sceneName != null)
+                requestFields.Add("scene-name", sceneName);
+
+            JObject response = SendRequest("GetSceneItemProperties", requestFields);
+            return JsonConvert.DeserializeObject<SceneItemProperties>(response.ToString());
+        }
+
+        /// <summary>
+        /// Get the current properties of a Text GDI Plus source.
+        /// </summary>
+        /// <param name="sourceName">The name of the source</param>
+        public TextGDIPlusProperties GetTextGDIPlusProperties(string sourceName)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("source", sourceName);
+
+            JObject response = SendRequest("GetTextGDIPlusProperties", requestFields);
+            return JsonConvert.DeserializeObject<TextGDIPlusProperties>(response.ToString());
+        }
+
+        /// <summary>
+        /// Set the current properties of a Text GDI Plus source.
+        /// </summary>
+        /// <param name="properties">properties for the source</param>
+        public void SetTextGDIPlusProperties(TextGDIPlusProperties properties)
+        {
+            var requestFields = JObject.Parse(JsonConvert.SerializeObject(properties));
+
+            SendRequest("SetTextGDIPlusProperties", requestFields);
+            
+        }
+
+
+
+        /// <summary>
+        /// Move a filter in the chain (relative positioning)
+        /// </summary>
+        /// <param name="sourceName">Scene Name</param>
+        /// <param name="filterName">Filter Name</param>
+        /// <param name="movement">Direction to move</param>
+        public void MoveSourceFilter(string sourceName, string filterName, FilterMovementType movement)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("sourceName", sourceName);
+            requestFields.Add("filterName", filterName);
+            requestFields.Add("movementType", movement.ToString().ToLower());
+
+            SendRequest("MoveSourceFilter", requestFields);
+        }
+
+        /// <summary>
+        /// Move a filter in the chain (absolute index positioning)
+        /// </summary>
+        /// <param name="sourceName">Scene Name</param>
+        /// <param name="filterName">Filter Name</param>
+        /// <param name="newIndex">Desired position of the filter in the chain</param>
+        public void ReorderSourceFilter(string sourceName, string filterName, int newIndex)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("sourceName", sourceName);
+            requestFields.Add("filterName", filterName);
+            requestFields.Add("newIndex", newIndex);
+
+            SendRequest("ReorderSourceFilter", requestFields);
+        }
+
+        /// <summary>
         /// Apply settings to a source filter
         /// </summary>
-        /// <param name="sourceName"></param>
-        /// <param name="filterName"></param>
-        /// <param name="filterSettings"></param>
+        /// <param name="sourceName">Source with filter</param>
+        /// <param name="filterName">Filter name</param>
+        /// <param name="filterSettings">Filter settings</param>
         public void SetSourceFilterSettings(string sourceName, string filterName, JObject filterSettings)
         {
             var requestFields = new JObject();
             requestFields.Add("sourceName", sourceName);
             requestFields.Add("filterName", filterName);
             requestFields.Add("filterSettings", filterSettings);
-
 
             SendRequest("SetSourceFilterSettings", requestFields);
         }
@@ -119,17 +314,10 @@ namespace OBSWebsocketDotNet
         {
             var requestFields = new JObject();
             requestFields.Add("sourceName", sourceName);
-            
+
             JObject response = SendRequest("GetSourceFilters", requestFields);
 
-            List<FilterSettings> filters = new List<FilterSettings>();
-            JsonConvert.PopulateObject(response["filters"].ToString(), filters);
-            
-
-
-           //TODO - loop filter types and create them
-
-            return filters;
+            return JsonConvert.DeserializeObject<List<FilterSettings>>(response["filters"].ToString());
         }
 
         /// <summary>
@@ -146,7 +334,8 @@ namespace OBSWebsocketDotNet
             {
                 SendRequest("RemoveFilterFromSource", requestFields);
                 return true;
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 //TODO exception handling
                 Console.WriteLine(e.Message);
@@ -168,7 +357,6 @@ namespace OBSWebsocketDotNet
             requestFields.Add("filterType", filterType);
             requestFields.Add("filterName", filterName);
             requestFields.Add("filterSettings", filterSettings);
-
 
             var result = SendRequest("AddFilterToSource", requestFields);
         }
@@ -206,14 +394,12 @@ namespace OBSWebsocketDotNet
         /// <returns>A <see cref="List{T}"/> of all transition names</returns>
         public List<string> ListTransitions()
         {
-            JObject response = SendRequest("GetTransitionList");
-            JArray items = (JArray)response["transitions"];
-
+            var transitions = GetTransitionList();
+            
             List<string> transitionNames = new List<string>();
-            foreach (JObject item in items)
-            {
-                transitionNames.Add((string)item["name"]);
-            }
+            foreach (var item in transitions.Transitions)
+                transitionNames.Add(item.Name);
+            
 
             return transitionNames;
         }
@@ -349,6 +535,21 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Sets the scene specific properties of a source. Unspecified properties will remain unchanged. Coordinates are relative to the item's parent (the scene or group it belongs to).
+        /// </summary>
+        /// <param name="props">Object containing changes</param>
+        /// <param name="sceneName">Option scene name</param>
+        public void SetSceneItemProperties(SceneItemProperties props, string sceneName = null)
+        {
+            var requestFields = JObject.Parse(JsonConvert.SerializeObject(props));
+
+            if (sceneName != null)
+                requestFields.Add("scene-name", sceneName);
+
+            SendRequest("SetSceneItemTransform", requestFields);
+        }
+
+        /// <summary>
         /// Set the current scene collection to the specified one
         /// </summary>
         /// <param name="scName">Desired scene collection name</param>
@@ -380,7 +581,7 @@ namespace OBSWebsocketDotNet
             var items = (JArray)response["scene-collections"];
 
             List<string> sceneCollections = new List<string>();
-            foreach(JObject item in items)
+            foreach (JObject item in items)
             {
                 sceneCollections.Add((string)item["sc-name"]);
             }
@@ -446,6 +647,14 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Toggle Streaming
+        /// </summary>
+        public void StartStopStreaming()
+        {
+            SendRequest("StartStopStreaming");
+        }
+
+        /// <summary>
         /// Start recording. Will trigger an error if recording is already active.
         /// </summary>
         public void StartRecording()
@@ -459,6 +668,14 @@ namespace OBSWebsocketDotNet
         public void StopRecording()
         {
             SendRequest("StopRecording");
+        }
+
+        /// <summary>
+        /// Toggle recording
+        /// </summary>
+        public void StartStopRecording()
+        {
+            SendRequest("StartStopRecording");
         }
 
         /// <summary>
@@ -493,10 +710,46 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Get duration of the currently selected transition (if supported)
+        /// </summary>
+        /// <returns>Current transition duration (in milliseconds)</returns>
+        public GetTransitionListInfo GetTransitionList()
+        {
+            var response = SendRequest("GetTransitionList");
+
+            return JsonConvert.DeserializeObject<GetTransitionListInfo>(response.ToString());
+        }
+
+        /// <summary>
         /// Get status of Studio Mode
         /// </summary>
         /// <returns>Studio Mode status (on/off)</returns>
         public bool StudioModeEnabled()
+        {
+            var response = SendRequest("GetStudioModeStatus");
+            return (bool)response["studio-mode"];
+        }
+
+        /// <summary>
+        /// Disable Studio Mode
+        /// </summary>
+        public void DisableStudioMode()
+        {
+            SendRequest("DisableStudioMode");
+        }
+
+        /// <summary>
+        /// Enable Studio Mode
+        /// </summary>
+        public void EnableStudioMode()
+        {
+            SendRequest("EnableStudioMode");
+        }
+
+        /// <summary>
+        /// Enable Studio Mode
+        /// </summary>
+        public bool GetStudioModeStatus()
         {
             var response = SendRequest("GetStudioModeStatus");
             return (bool)response["studio-mode"];
@@ -509,9 +762,9 @@ namespace OBSWebsocketDotNet
         public void SetStudioMode(bool enable)
         {
             if (enable)
-                SendRequest("EnableStudioMode");
+                EnableStudioMode();
             else
-                SendRequest("DisableStudioMode");
+                DisableStudioMode();
         }
 
         /// <summary>
@@ -564,7 +817,7 @@ namespace OBSWebsocketDotNet
         {
             var requestFields = new JObject();
 
-            if(transitionDuration > -1 || transitionName != null)
+            if (transitionDuration > -1 || transitionName != null)
             {
                 var withTransition = new JObject();
 
@@ -622,6 +875,14 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Toggle replay buffer
+        /// </summary>
+        public void StartStopReplayBuffer()
+        {
+            SendRequest("StartStopReplayBuffer");
+        }
+
+        /// <summary>
         /// Save and flush the contents of the Replay Buffer to disk. Basically
         /// the same as triggering the "Save Replay Buffer" hotkey in OBS.
         /// Triggers an error if Replay Buffer is not active.
@@ -655,6 +916,50 @@ namespace OBSWebsocketDotNet
             requestFields.Add("source", sourceName);
             var response = SendRequest("GetSyncOffset", requestFields);
             return (int)response["offset"];
+        }
+
+        /// <summary>
+        /// Deletes a scene item
+        /// </summary>
+        /// <param name="sceneItem">Scene item, requires name or id of item</param>
+        /// /// <param name="sceneName">Scene name to delete item from (optional)</param>
+        public void DeleteSceneItem(SceneItemStub sceneItem, string sceneName = null)
+        {
+            var requestFields = new JObject();
+
+            if (sceneName != null)
+                requestFields.Add("scene-name");
+
+            JObject minReqs = new JObject();
+            if (sceneItem.SourceName != null)
+                minReqs.Add("name", sceneItem.SourceName);
+
+            minReqs.Add("id", sceneItem.ID);
+
+            requestFields.Add("item", minReqs);
+
+            SendRequest("DeleteSceneItem", requestFields);
+        }
+
+        /// <summary>
+        /// Deletes a scene item
+        /// </summary>
+        /// <param name="sceneItemId">Scene item id</param>
+        /// /// <param name="sceneName">Scene name to delete item from (optional)</param>
+        public void DeleteSceneItem(int sceneItemId, string sceneName = null)
+        {
+            var requestFields = new JObject();
+
+            if (sceneName != null)
+                requestFields.Add("scene-name");
+
+            JObject minReqs = new JObject();
+
+            minReqs.Add("id", sceneItemId);
+
+            requestFields.Add("item", minReqs);
+
+            SendRequest("DeleteSceneItem", requestFields);
         }
 
         /// <summary>
@@ -693,6 +998,91 @@ namespace OBSWebsocketDotNet
         }
 
         /// <summary>
+        /// Reset a scene item
+        /// </summary>
+        /// <param name="itemName">Name of the source item</param>
+        /// <param name="sceneName">Name of the scene the source belongs to. Defaults to the current scene.</param>
+        public void ResetSceneItem(string itemName, string sceneName = null)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("item", itemName);
+
+            if (sceneName != null)
+                requestFields.Add("scene-name");
+
+            SendRequest("ResetSceneItem", requestFields);
+        }
+
+        /// <summary>
+        /// Send the provided text as embedded CEA-608 caption data. As of OBS Studio 23.1, captions are not yet available on Linux.
+        /// </summary>
+        /// <param name="text">Captions text</param>
+        public void SendCaptions(string text)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("text", text);
+
+            SendRequest("SendCaptions", requestFields);
+        }
+
+        /// <summary>
+        /// Set the filename formatting string
+        /// </summary>
+        /// <param name="filenameFormatting">Filename formatting string to set</param>
+        public void SetFilenameFormatting(string filenameFormatting)
+        {
+            var requestFields = new JObject();
+            requestFields.Add("filename-formatting", filenameFormatting);
+
+            SendRequest("SetFilenameFormatting", requestFields);
+        }
+
+        /// <summary>
+        /// Set the relative crop coordinates of the specified source item
+        /// </summary>
+        /// <param name="fromSceneName">Source of the scene item</param>
+        /// <param name="toSceneName">Destination for the scene item</param>
+        /// <param name="sceneItem">Scene item, requires name or id</param>
+        public void DuplicateSceneItem(string fromSceneName, string toSceneName, SceneItem sceneItem)
+        {
+            var requestFields = new JObject();
+
+            requestFields.Add("fromScene", fromSceneName);
+            requestFields.Add("toScene", toSceneName);
+
+            JObject minReqs = new JObject();
+            if (sceneItem.SourceName != null)
+                minReqs.Add("name", sceneItem.SourceName);
+
+            minReqs.Add("id", sceneItem.ID);
+
+            requestFields.Add("item", minReqs);
+
+            SendRequest("DuplicateSceneItem", requestFields);
+        }
+
+        /// <summary>
+        /// Set the relative crop coordinates of the specified source item
+        /// </summary>
+        /// <param name="fromSceneName">Source of the scene item</param>
+        /// <param name="toSceneName">Destination for the scene item</param>
+        /// <param name="sceneItemID">Scene item id to duplicate</param>
+        public void DuplicateSceneItem(string fromSceneName, string toSceneName, int sceneItemID)
+        {
+            var requestFields = new JObject();
+
+            requestFields.Add("fromScene", fromSceneName);
+            requestFields.Add("toScene", toSceneName);
+
+            JObject minReqs = new JObject();
+            minReqs.Add("id", sceneItemID);
+
+            requestFields.Add("item", minReqs);
+
+            SendRequest("DuplicateSceneItem", requestFields);
+        }
+
+        /// <summary>
         /// Get names of configured special sources (like Desktop Audio
         /// and Mic sources)
         /// </summary>
@@ -701,11 +1091,11 @@ namespace OBSWebsocketDotNet
         {
             var response = SendRequest("GetSpecialSources");
             var sources = new Dictionary<string, string>();
-            foreach(KeyValuePair<string, JToken> x in response)
+            foreach (KeyValuePair<string, JToken> x in response)
             {
                 string key = x.Key;
                 string value = (string)x.Value;
-                if(key != "request-type" && key != "message-id")
+                if (key != "request-type" && key != "message-id")
                 {
                     sources.Add(key, value);
                 }
@@ -716,12 +1106,12 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Set current streaming settings
         /// </summary>
-        /// <param name="service"></param>
-        /// <param name="save"></param>
+        /// <param name="service">Service settings</param>
+        /// <param name="save">Save to disk</param>
         public void SetStreamingSettings(StreamingService service, bool save)
         {
             var jsonSettings = JsonConvert.SerializeObject(service.Settings);
-            
+
             var requestFields = new JObject();
             requestFields.Add("type", service.Type);
             requestFields.Add("settings", jsonSettings);
@@ -737,11 +1127,17 @@ namespace OBSWebsocketDotNet
         {
             var response = SendRequest("GetStreamSettings");
 
+            return JsonConvert.DeserializeObject<StreamingService>(response.ToString());
+        }
 
-            var service = new StreamingService();
-            JsonConvert.PopulateObject(response.ToString(), service);
-
-            return service;
+        /// <summary>
+        /// Set current streaming settings
+        /// </summary>
+        /// <param name="service">Service settings</param>
+        /// <param name="save">Save to disk</param>
+        public void SetStreamSettings(StreamingService service, bool save)
+        {
+            SetStreamingSettings(service, save);
         }
 
         /// <summary>
@@ -785,7 +1181,6 @@ namespace OBSWebsocketDotNet
             SendRequest("SetBrowserSourceProperties", request);
         }
 
-
         /// <summary>
         /// Enable/disable the heartbeat event
         /// </summary>
@@ -817,7 +1212,6 @@ namespace OBSWebsocketDotNet
             return settings;
         }
 
-
         /// <summary>
         /// Set settings of the specified source.
         /// </summary>
@@ -831,7 +1225,6 @@ namespace OBSWebsocketDotNet
             request.Add("sourceSettings", settings);
             if (sourceType != null)
                 request.Add("sourceType", sourceType);
-
 
             SendRequest("SetSourceSettings", request);
         }

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -532,12 +532,14 @@ namespace OBSWebsocketDotNet
         /// <param name="sceneName">Option scene name</param>
         public void SetSceneItemProperties(SceneItemProperties props, string sceneName = null)
         {
-            var requestFields = JObject.Parse(JsonConvert.SerializeObject(props));
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.NullValueHandling = NullValueHandling.Ignore;
+            var requestFields = JObject.Parse(JsonConvert.SerializeObject(props, settings));
 
             if (sceneName != null)
                 requestFields.Add("scene-name", sceneName);
 
-            SendRequest("SetSceneItemTransform", requestFields);
+            SendRequest("SetSceneItemProperties", requestFields);
         }
 
         /// <summary>

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -139,17 +139,8 @@ namespace OBSWebsocketDotNet
         /// <returns>A <see cref="List{OBSScene}" /> of <see cref="OBSScene"/> objects describing each scene</returns>
         public List<OBSScene> ListScenes()
         {
-            JObject response = SendRequest("GetSceneList");
-            JArray items = (JArray)response["scenes"];
-
-            var scenes = new List<OBSScene>();
-            foreach (JObject sceneData in items)
-            {
-                OBSScene scene = new OBSScene(sceneData);
-                scenes.Add(scene);
-            }
-
-            return scenes;
+            var response = GetSceneList();
+            return response.Scenes;
         }
 
         /// <summary>

--- a/obs-websocket-dotnet/OutputStatus.cs
+++ b/obs-websocket-dotnet/OutputStatus.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet
+{
+    /// <summary>
+    /// Status of streaming output and recording output
+    /// </summary>
+    public class OutputStatus
+    {
+        /// <summary>
+        /// True if streaming is started and running, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "streaming")]
+
+        public readonly bool IsStreaming;
+
+        /// <summary>
+        /// True if recording is started and running, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "recording")]
+        public readonly bool IsRecording;
+
+        /// <summary>
+        /// Builds the object from the JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public OutputStatus(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types.cs
+++ b/obs-websocket-dotnet/Types.cs
@@ -119,15 +119,15 @@ namespace OBSWebsocketDotNet
     /// </summary>
     /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
     /// <param name="transform">Transform data</param>
-    public delegate void SceneItemTransformCallback(OBSWebsocket sender, SceneItemTransform transform);
+    public delegate void SceneItemTransformCallback(OBSWebsocket sender, SceneItemTransformInfo transform);
 
 
     /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SourceAudioMixerChanged"/>
+    /// Callback by <see cref="OBSWebsocket.SourceAudioMixersChanged"/>
     /// </summary>
     /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
     /// <param name="mixerInfo">Mixer information that was updated</param>
-    public delegate void SourceAudioMixerChangedCallback(OBSWebsocket sender, AudioMixersChangedInfo mixerInfo);
+    public delegate void SourceAudioMixersChangedCallback(OBSWebsocket sender, AudioMixersChangedInfo mixerInfo);
 
 
 

--- a/obs-websocket-dotnet/Types.cs
+++ b/obs-websocket-dotnet/Types.cs
@@ -23,36 +23,12 @@
 */
 
 using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet.Types;
 using System;
 using System.Collections.Generic;
 
 namespace OBSWebsocketDotNet
 {
-    /// <summary>
-    /// Describes the state of an output (streaming or recording)
-    /// </summary>
-    public enum OutputState
-    {
-        /// <summary>
-        /// The output is initializing and doesn't produces frames yet
-        /// </summary>
-        Starting,
-
-        /// <summary>
-        /// The output is running and produces frames
-        /// </summary>
-        Started,
-
-        /// <summary>
-        /// The output is stopping and sends the last remaining frames in its buffer
-        /// </summary>
-        Stopping,
-
-        /// <summary>
-        /// The output is completely stopped
-        /// </summary>
-        Stopped
-    }
 
     /// <summary>
     /// Called by <see cref="OBSWebsocket.SceneChanged"/>
@@ -114,537 +90,121 @@ namespace OBSWebsocketDotNet
     public delegate void StudioModeChangeCallback(OBSWebsocket sender, bool enabled);
 
     /// <summary>
-    /// Describes a scene in OBS, along with its items
+    /// Called by <see cref="OBSWebsocket.Heartbeat"/>
     /// </summary>
-    public struct OBSScene
-    {
-        /// <summary>
-        /// OBS Scene name
-        /// </summary>
-        public string Name;
-
-        /// <summary>
-        /// Scene item list
-        /// </summary>
-        public List<SceneItem> Items;
-
-        /// <summary>
-        /// Builds the object from the JSON description
-        /// </summary>
-        /// <param name="data">JSON scene description as a <see cref="JObject" /></param>
-        public OBSScene(JObject data)
-        {
-            Name = (string)data["name"];
-            Items = new List<SceneItem>();
-
-            var sceneItems = (JArray)data["sources"];
-            foreach (JObject item in sceneItems)
-            {
-                Items.Add(new SceneItem(item));
-            }
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="heatbeat">heartbeat data</param>
+    public delegate void HeartBeatCallback(OBSWebsocket sender, Heartbeat heatbeat);
 
     /// <summary>
-    /// Describes a scene item in an OBS scene
+    /// Callback by <see cref="OBSWebsocket.SceneItemDeselected"/>
     /// </summary>
-    public struct SceneItem
-    {
-        /// <summary>
-        /// Source name
-        /// </summary>
-        public string SourceName;
-
-        /// <summary>
-        /// Source internal type
-        /// </summary>
-        public string InternalType;
-
-        /// <summary>
-        /// Source audio volume
-        /// </summary>
-        public float AudioVolume;
-
-        /// <summary>
-        /// Scene item horizontal position/offset
-        /// </summary>
-        public float XPos;
-
-        /// <summary>
-        /// Scene item vertical position/offset
-        /// </summary>
-        public float YPos;
-
-        /// <summary>
-        /// Item source width, without scaling and transforms applied
-        /// </summary>
-        public int SourceWidth;
-
-        /// <summary>
-        /// Item source height, without scaling and transforms applied
-        /// </summary>
-        public int SourceHeight;
-
-        /// <summary>
-        /// Item width
-        /// </summary>
-        public float Width;
-
-        /// <summary>
-        /// Item height
-        /// </summary>
-        public float Height;
-
-        /// <summary>
-        /// Builds the object from the JSON scene description
-        /// </summary>
-        /// <param name="data">JSON item description as a <see cref="JObject"/></param>
-        public SceneItem(JObject data)
-        {
-            SourceName = (string)data["name"];
-            InternalType = (string)data["type"];
-
-            AudioVolume = (float)data["volume"];
-            XPos = (float)data["x"];
-            YPos = (float)data["y"];
-            SourceWidth = (int)data["source_cx"];
-            SourceHeight = (int)data["source_cy"];
-            Width = (float)data["cx"];
-            Height = (float)data["cy"];
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sceneName">Name of the scene item was in</param>
+    /// <param name="itemName">Name of the item deselected</param>
+    /// <param name="itemId">Id of the item deselected</param>
+    public delegate void SceneItemDeselectedCallback(OBSWebsocket sender, string sceneName, string itemName, string itemId);
 
     /// <summary>
-    /// Data required by authentication
+    /// Callback by <see cref="OBSWebsocket.SceneItemSelected"/>
     /// </summary>
-    public struct OBSAuthInfo
-    {
-        /// <summary>
-        /// True if authentication is required, false otherwise
-        /// </summary>
-        public readonly bool AuthRequired;
-
-        /// <summary>
-        /// Authentication challenge
-        /// </summary>
-        public readonly string Challenge;
-
-        /// <summary>
-        /// Password salt
-        /// </summary>
-        public readonly string PasswordSalt;
-
-        /// <summary>
-        /// Builds the object from JSON response body
-        /// </summary>
-        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
-        public OBSAuthInfo(JObject data)
-        {
-            AuthRequired = (bool)data["authRequired"];
-            Challenge = (string)data["challenge"];
-            PasswordSalt = (string)data["salt"];
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sceneName">Name of the scene item was in</param>
+    /// <param name="itemName">Name of the item seletected</param>
+    /// <param name="itemId">Id of the item selected</param>
+    public delegate void SceneItemSelectedCallback(OBSWebsocket sender, string sceneName, string itemName, string itemId);
 
     /// <summary>
-    /// Version info of the plugin, the API and OBS Studio
+    /// Callback by <see cref="OBSWebsocket.SceneItemTransformChanged"/>
     /// </summary>
-    public struct OBSVersion
-    {
-        /// <summary>
-        /// obs-websocket plugin version
-        /// </summary>
-        public readonly string PluginVersion;
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="transform">Transform data</param>
+    public delegate void SceneItemTransformCallback(OBSWebsocket sender, SceneItemTransform transform);
 
-        /// <summary>
-        /// OBS Studio version
-        /// </summary>
-        public readonly string OBSStudioVersion;
-
-        /// <summary>
-        /// Builds the object from the JSON response body
-        /// </summary>
-        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
-        public OBSVersion(JObject data)
-        {
-            PluginVersion = (string)data["obs-websocket-version"];
-            OBSStudioVersion = (string)data["obs-studio-version"];
-        }
-    }
 
     /// <summary>
-    /// Data of a stream status update
+    /// Callback by <see cref="OBSWebsocket.SourceAudioMixerChanged"/>
     /// </summary>
-    public struct StreamStatus
-    {
-        /// <summary>
-        /// True if streaming is started and running, false otherwise
-        /// </summary>
-        public readonly bool Streaming;
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="mixerInfo">Mixer information that was updated</param>
+    public delegate void SourceAudioMixerChangedCallback(OBSWebsocket sender, AudioMixersChangedInfo mixerInfo);
 
-        /// <summary>
-        /// True if recording is started and running, false otherwise
-        /// </summary>
-        public readonly bool Recording;
 
-        /// <summary>
-        /// Stream bitrate in bytes per second
-        /// </summary>
-        public readonly int BytesPerSec;
-
-        /// <summary>
-        /// Stream bitrate in kilobits per second
-        /// </summary>
-        public readonly int KbitsPerSec;
-
-        /// <summary>
-        /// RTMP output strain
-        /// </summary>
-        public readonly float Strain;
-
-        /// <summary>
-        /// Total time since streaming start
-        /// </summary>
-        public readonly int TotalStreamTime;
-
-        /// <summary>
-        /// Number of frames sent since streaming start
-        /// </summary>
-        public readonly int TotalFrames;
-
-        /// <summary>
-        /// Overall number of frames dropped since streaming start
-        /// </summary>
-        public readonly int DroppedFrames;
-
-        /// <summary>
-        /// Current framerate in Frames Per Second
-        /// </summary>
-        public readonly float FPS;
-
-        /// <summary>
-        /// Builds the object from the JSON event body
-        /// </summary>
-        /// <param name="data">JSON event body as a <see cref="JObject"/></param>
-        public StreamStatus(JObject data)
-        {
-            Streaming = (bool)data["streaming"];
-            Recording = (bool)data["recording"];
-
-            BytesPerSec = (int)data["bytes-per-sec"];
-            KbitsPerSec = (int)data["kbits-per-sec"];
-            Strain = (float)data["strain"];
-            TotalStreamTime = (int)data["total-stream-time"];
-
-            TotalFrames = (int)data["num-total-frames"];
-            DroppedFrames = (int)data["num-dropped-frames"];
-            FPS = (float)data["fps"];
-        }
-    }
 
     /// <summary>
-    /// Status of streaming output and recording output
+    /// Callback by <see cref="OBSWebsocket.SourceAudioSyncOffsetChanged"/>
     /// </summary>
-    public struct OutputStatus
-    {
-        /// <summary>
-        /// True if streaming is started and running, false otherwise
-        /// </summary>
-        public readonly bool IsStreaming;
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Name of the source for the offset change</param>
+    /// <param name="syncOffset">Sync offset value</param>
+    public delegate void SourceAudioSyncOffsetCallback(OBSWebsocket sender, string sourceName, int syncOffset);
 
-        /// <summary>
-        /// True if recording is started and running, false otherwise
-        /// </summary>
-        public readonly bool IsRecording;
-
-        /// <summary>
-        /// Builds the object from the JSON response body
-        /// </summary>
-        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
-        public OutputStatus(JObject data)
-        {
-            IsStreaming = (bool)data["streaming"];
-            IsRecording = (bool)data["recording"];
-        }
-    }
 
     /// <summary>
-    /// Current transition settings
+    /// Callback by <see cref="OBSWebsocket.SourceCreated"/>
     /// </summary>
-    public struct TransitionSettings
-    {
-        /// <summary>
-        /// Transition name
-        /// </summary>
-        public readonly string Name;
-
-        /// <summary>
-        /// Transition duration in milliseconds
-        /// </summary>
-        public readonly int Duration;
-
-        /// <summary>
-        /// Builds the object from the JSON response body
-        /// </summary>
-        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
-        public TransitionSettings(JObject data)
-        {
-            Name = (string)data["name"];
-            Duration = (int)data["duration"];
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="settings">Newly created source settings</param>
+    public delegate void SourceCreatedCallback(OBSWebsocket sender, SourceSettings settings);
 
     /// <summary>
-    /// Volume settings of an OBS source
+    /// Callback by <see cref="OBSWebsocket.SourceDestroyed"/>
     /// </summary>
-    public struct VolumeInfo
-    {
-        /// <summary>
-        /// Source volume in linear scale (0.0 to 1.0)
-        /// </summary>
-        public readonly float Volume;
-
-        /// <summary>
-        /// True if source is muted, false otherwise
-        /// </summary>
-        public readonly bool Muted;
-
-        /// <summary>
-        /// Builds the object from the JSON response body
-        /// </summary>
-        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
-        public VolumeInfo(JObject data)
-        {
-            Volume = (float)data["volume"];
-            Muted = (bool)data["muted"];
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Newly destroyed source information</param>
+    /// <param name="sourceKind">Kind of source destroyed</param>
+    /// <param name="sourceType">Type of source destroyed</param>
+    public delegate void SourceDestroyedCallback(OBSWebsocket sender, string sourceName, string sourceType, string sourceKind);
 
     /// <summary>
-    /// Streaming settings
+    /// Callback by <see cref="OBSWebsocket.SourceRenamed"/>
     /// </summary>
-    public struct StreamingService
-    {
-        /// <summary>
-        /// Type of streaming service
-        /// </summary>
-        public string Type;
-
-        /// <summary>
-        /// Streaming service settings (JSON data)
-        /// </summary>
-        public JObject Settings;
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="newName">New name of source</param>
+    /// <param name="previousName">Previous name of source</param>
+    public delegate void SourceRenamedCallback(OBSWebsocket sender, string newName, string previousName);
 
     /// <summary>
-    /// Common RTMP settings (predefined streaming services list)
+    /// Callback by <see cref="OBSWebsocket.SourceMuteStateChanged"/>
     /// </summary>
-    public struct CommonRTMPStreamingService
-    {
-        /// <summary>
-        /// Streaming provider name
-        /// </summary>
-        public string ServiceName;
-
-        /// <summary>
-        /// Streaming server URL;
-        /// </summary>
-        public string ServerUrl;
-
-        /// <summary>
-        /// Stream key
-        /// </summary>
-        public string StreamKey;
-
-        /// <summary>
-        /// Construct object from data provided by <see cref="StreamingService.Settings"/>
-        /// </summary>
-        /// <param name="settings"></param>
-        public CommonRTMPStreamingService(JObject settings)
-        {
-            ServiceName = (string)settings["service"];
-            ServerUrl = (string)settings["server"];
-            StreamKey = (string)settings["key"];
-        }
-
-        /// <summary>
-        /// Convert to JSON object
-        /// </summary>
-        /// <returns></returns>
-        public JObject ToJSON()
-        {
-            var obj = new JObject();
-            obj.Add("service", ServiceName);
-            obj.Add("server", ServerUrl);
-            obj.Add("key", StreamKey);
-            return obj;
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Name of source</param>
+    /// <param name="muted">Current mute state of source</param>
+    public delegate void SourceMuteStateChangedCallback(OBSWebsocket sender, string sourceName, bool muted);
 
     /// <summary>
-    /// Custom RTMP settings (fully customizable RTMP credentials)
+    /// Callback by <see cref="OBSWebsocket.SourceVolumeChanged"/>
     /// </summary>
-    public struct CustomRTMPStreamingService
-    {
-        /// <summary>
-        /// RTMP server URL
-        /// </summary>
-        public string ServerAddress;
-
-        /// <summary>
-        /// RTMP stream key (URL suffix)
-        /// </summary>
-        public string StreamKey;
-
-        /// <summary>
-        /// Tell OBS' RTMP client to authenticate to the server
-        /// </summary>
-        public bool UseAuthentication;
-
-        /// <summary>
-        /// Username used if authentication is enabled
-        /// </summary>
-        public string AuthUsername;
-
-        /// <summary>
-        /// Password used if authentication is enabled
-        /// </summary>
-        public string AuthPassword;
-
-        /// <summary>
-        /// Construct object from data provided by <see cref="StreamingService.Settings"/>
-        /// </summary>
-        /// <param name="settings"></param>
-        public CustomRTMPStreamingService(JObject settings)
-        {
-            ServerAddress = (string)settings["server"];
-            StreamKey = (string)settings["key"];
-            UseAuthentication = (bool)settings["use_auth"];
-            AuthUsername = (string)settings["username"];
-            AuthPassword = (string)settings["password"];
-        }
-
-        /// <summary>
-        /// Convert to JSON object
-        /// </summary>
-        /// <returns></returns>
-        public JObject ToJSON()
-        {
-            var obj = new JObject();
-            obj.Add("server", ServerAddress);
-            obj.Add("key", StreamKey);
-            obj.Add("use_auth", UseAuthentication);
-            obj.Add("username", AuthUsername);
-            obj.Add("password", AuthPassword);
-            return obj;
-        }
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Name of source</param>
+    /// <param name="volume">Current volume level of source</param>
+    public delegate void SourceVolumeChangedCallback(OBSWebsocket sender, string sourceName, float volume);
 
     /// <summary>
-    /// Crop coordinates for a scene item
+    /// Callback by <see cref="OBSWebsocket.SourceFilterRemoved"/>
     /// </summary>
-    public struct SceneItemCropInfo
-    {
-        /// <summary>
-        /// Top crop (in pixels)
-        /// </summary>
-        public int Top;
-
-        /// <summary>
-        /// Bottom crop (in pixels)
-        /// </summary>
-        public int Bottom;
-
-        /// <summary>
-        /// Left crop (in pixels)
-        /// </summary>
-        public int Left;
-
-        /// <summary>
-        /// Right crop (in pixels)
-        /// </summary>
-        public int Right;
-    }
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Name of source</param>
+    /// <param name="filterName">Name of removed filter</param>
+    public delegate void SourceFilterRemovedCallback(OBSWebsocket sender, string sourceName, string filterName);
 
     /// <summary>
-    /// BrowserSource source properties
+    /// Callback by <see cref="OBSWebsocket.SourceFilterAdded"/>
     /// </summary>
-    public struct BrowserSourceProperties
-    {
-        /// <summary>
-        /// URL to load in the embedded browser
-        /// </summary>
-        public string URL;
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Name of source</param>
+    /// <param name="filterName">Name of filter</param>
+    /// <param name="filterType">Type of filter</param>
+    /// <param name="filterSettings">Settings for filter</param>
+    public delegate void SourceFilterAddedCallback(OBSWebsocket sender, string sourceName, string filterName, string filterType, JObject filterSettings);
 
-        /// <summary>
-        /// true if the URL points to a local file, false otherwise.
-        /// </summary>
-        public bool IsLocalFile;
-
-        /// <summary>
-        /// Additional CSS to apply to the page
-        /// </summary>
-        public string CustomCSS;
-
-        /// <summary>
-        /// Embedded browser render (viewport) width
-        /// </summary>
-        public int Width;
-
-        /// <summary>
-        /// Embedded browser render (viewport) height
-        /// </summary>
-        public int Height;
-
-        /// <summary>
-        /// Embedded browser render frames per second
-        /// </summary>
-        public int FPS;
-
-        /// <summary>
-        /// true if source should be disabled (inactive) when not visible, false otherwise
-        /// </summary>
-        public bool ShutdownWhenNotVisible;
-
-        /// <summary>
-        /// true if source should be visible, false otherwise
-        /// </summary>
-        public bool Visible;
-
-        /// <summary>
-        /// Construct the object from JSON response data
-        /// </summary>
-        /// <param name="props"></param>
-        public BrowserSourceProperties(JObject props)
-        {
-            URL = (string)props["url"];
-            IsLocalFile = (bool)props["is_local_file"];
-            CustomCSS = (string)props["css"];
-            Width = (int)props["width"];
-            Height = (int)props["height"];
-            FPS = (int)props["fps"];
-            ShutdownWhenNotVisible = (bool)props["shutdown"];
-            Visible = (bool)props["render"];
-        }
-
-        /// <summary>
-        /// Convert the object back to JSON
-        /// </summary>
-        /// <returns></returns>
-        public JObject ToJSON()
-        {
-            var obj = new JObject();
-            obj.Add("url", URL);
-            obj.Add("is_local_file", IsLocalFile);
-            obj.Add("css", CustomCSS);
-            obj.Add("width", Width);
-            obj.Add("height", Height);
-            obj.Add("fps", FPS);
-            obj.Add("shutdown", ShutdownWhenNotVisible);
-            obj.Add("render", Visible);
-            return obj;
-        }
-    }
+    /// <summary>
+    /// Callback by <see cref="OBSWebsocket.SourceFiltersReordered"/>
+    /// </summary>
+    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
+    /// <param name="sourceName">Name of source</param>
+    /// <param name="filters">Current order of filters for source</param>
+    public delegate void SourceFiltersReorderedCallback(OBSWebsocket sender, string sourceName, List<FilterReorderItem> filters);
 
     /// <summary>
     /// Thrown if authentication fails

--- a/obs-websocket-dotnet/Types/AudioMixerChannel.cs
+++ b/obs-websocket-dotnet/Types/AudioMixerChannel.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/AudioMixerChannel.cs
+++ b/obs-websocket-dotnet/Types/AudioMixerChannel.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Audio Mixer Channel information
+    /// </summary>
+    public class AudioMixerChannel
+    {
+        /// <summary>
+        /// Is channel enabled
+        /// </summary>
+        [JsonProperty(PropertyName = "enabled")]
+        public bool Enabled { set; get; }
+
+        /// <summary>
+        /// ID of the channel
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public int ID { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/AudioMixersChangedInfo.cs
+++ b/obs-websocket-dotnet/Types/AudioMixersChangedInfo.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -29,7 +26,6 @@ namespace OBSWebsocketDotNet.Types
         /// </summary>
         [JsonProperty(PropertyName = "hexMixersValue")]
         public string HexMixersValue { set; get; }
-
 
         /// <summary>
         /// Create mixer response

--- a/obs-websocket-dotnet/Types/AudioMixersChangedInfo.cs
+++ b/obs-websocket-dotnet/Types/AudioMixersChangedInfo.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Response from audio mixer change event
+    /// </summary>
+    public class AudioMixersChangedInfo
+    {
+        /// <summary>
+        /// Mixer source name
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceName")]
+        public string SourceName { set; get; }
+
+        /// <summary>
+        /// Routing status of the source for each audio mixer (array of 6 values)
+        /// </summary>
+        [JsonProperty(PropertyName = "mixers")]
+        public List<AudioMixerChannel> Mixers { get; set; }
+
+        /// <summary>
+        /// Raw mixer flags (little-endian, one bit per mixer) as an hexadecimal value
+        /// </summary>
+        [JsonProperty(PropertyName = "hexMixersValue")]
+        public string HexMixersValue { set; get; }
+
+
+        /// <summary>
+        /// Create mixer response
+        /// </summary>
+        /// <param name="body"></param>
+        public AudioMixersChangedInfo(JObject body)
+        {
+            JsonConvert.PopulateObject(body.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
+++ b/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
@@ -17,7 +17,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// URL to load in the embedded browser
         /// </summary>
-        [JsonProperty(PropertyName = "fps")]
+        [JsonProperty(PropertyName = "url")]
         public string URL;
 
         /// <summary>

--- a/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
+++ b/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
@@ -1,0 +1,97 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// BrowserSource source properties
+    /// </summary>
+    public class BrowserSourceProperties
+    {
+
+        /// <summary>
+        /// Source name for the browser properties
+        /// </summary>
+        [JsonProperty(PropertyName = "source")]
+        public string Source;
+
+        /// <summary>
+        /// URL to load in the embedded browser
+        /// </summary>
+        [JsonProperty(PropertyName = "fps")]
+        public string URL;
+
+        /// <summary>
+        /// true if the URL points to a local file, false otherwise.
+        /// </summary>
+        [JsonProperty(PropertyName = "is_local_file")]
+        public bool IsLocalFile;
+
+        /// <summary>
+        /// Additional CSS to apply to the page
+        /// </summary>
+        [JsonProperty(PropertyName = "css")]
+        public string CustomCSS;
+
+        /// <summary>
+        /// Embedded browser render (viewport) width
+        /// </summary>
+        [JsonProperty(PropertyName = "width")]
+        public int Width;
+
+        /// <summary>
+        /// Embedded browser render (viewport) height
+        /// </summary>
+        [JsonProperty(PropertyName = "height")]
+        public int Height;
+
+        /// <summary>
+        /// Embedded browser render frames per second
+        /// </summary>
+        [JsonProperty(PropertyName = "fps")]
+        public int FPS;
+
+        /// <summary>
+        /// true if source should be disabled (inactive) when not visible, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "shutdown")]
+        public bool ShutdownWhenNotVisible;
+
+        /// <summary>
+        /// true if source should be visible, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "render")]
+        public bool Visible;
+
+        /// <summary>
+        /// Construct the object from JSON response data
+        /// </summary>
+        /// <param name="props"></param>
+        public BrowserSourceProperties(JObject props)
+        {
+            JsonConvert.PopulateObject(props.ToString(), this);
+        }
+
+        /// <summary>
+        /// Convert the object back to JSON
+        /// </summary>
+        /// <returns></returns>
+        public JObject ToJSONOLD()
+        {
+            var obj = new JObject();
+            obj.Add("url", URL);
+            obj.Add("is_local_file", IsLocalFile);
+            obj.Add("css", CustomCSS);
+            obj.Add("width", Width);
+            obj.Add("height", Height);
+            obj.Add("fps", FPS);
+            obj.Add("shutdown", ShutdownWhenNotVisible);
+            obj.Add("render", Visible);
+            return obj;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
+++ b/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -12,7 +8,6 @@ namespace OBSWebsocketDotNet.Types
     /// </summary>
     public class BrowserSourceProperties
     {
-
         /// <summary>
         /// Source name for the browser properties
         /// </summary>

--- a/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
+++ b/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
@@ -70,23 +70,5 @@ namespace OBSWebsocketDotNet.Types
         {
             JsonConvert.PopulateObject(props.ToString(), this);
         }
-
-        /// <summary>
-        /// Convert the object back to JSON
-        /// </summary>
-        /// <returns></returns>
-        public JObject ToJSONOLD()
-        {
-            var obj = new JObject();
-            obj.Add("url", URL);
-            obj.Add("is_local_file", IsLocalFile);
-            obj.Add("css", CustomCSS);
-            obj.Add("width", Width);
-            obj.Add("height", Height);
-            obj.Add("fps", FPS);
-            obj.Add("shutdown", ShutdownWhenNotVisible);
-            obj.Add("render", Visible);
-            return obj;
-        }
     }
 }

--- a/obs-websocket-dotnet/Types/CommonRTMPStreamingService.cs
+++ b/obs-websocket-dotnet/Types/CommonRTMPStreamingService.cs
@@ -34,18 +34,5 @@ namespace OBSWebsocketDotNet.Types
         {
             JsonConvert.PopulateObject(settings.ToString(), this);
         }
-
-        /// <summary>
-        /// Convert to JSON object
-        /// </summary>
-        /// <returns></returns>
-        public JObject ToJSONOLD()
-        {
-            var obj = new JObject();
-            obj.Add("service", ServiceName);
-            obj.Add("server", ServerUrl);
-            obj.Add("key", StreamKey);
-            return obj;
-        }
     }
 }

--- a/obs-websocket-dotnet/Types/CommonRTMPStreamingService.cs
+++ b/obs-websocket-dotnet/Types/CommonRTMPStreamingService.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Common RTMP settings (predefined streaming services list)
+    /// </summary>
+    public class CommonRTMPStreamingService
+    {
+        /// <summary>
+        /// Streaming provider name
+        /// </summary>
+        [JsonProperty(PropertyName = "service")]
+        public string ServiceName;
+
+        /// <summary>
+        /// Streaming server URL;
+        /// </summary>
+        [JsonProperty(PropertyName = "server")]
+        public string ServerUrl;
+
+        /// <summary>
+        /// Stream key
+        /// </summary>
+        [JsonProperty(PropertyName = "key")]
+        public string StreamKey;
+
+        /// <summary>
+        /// Construct object from data provided by <see cref="StreamingService.Settings"/>
+        /// </summary>
+        /// <param name="settings"></param>
+        public CommonRTMPStreamingService(JObject settings)
+        {
+            JsonConvert.PopulateObject(settings.ToString(), this);
+        }
+
+        /// <summary>
+        /// Convert to JSON object
+        /// </summary>
+        /// <returns></returns>
+        public JObject ToJSONOLD()
+        {
+            var obj = new JObject();
+            obj.Add("service", ServiceName);
+            obj.Add("server", ServerUrl);
+            obj.Add("key", StreamKey);
+            return obj;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/CommonRTMPStreamingService.cs
+++ b/obs-websocket-dotnet/Types/CommonRTMPStreamingService.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/CustomRTMPStreamingService.cs
+++ b/obs-websocket-dotnet/Types/CustomRTMPStreamingService.cs
@@ -46,20 +46,5 @@ namespace OBSWebsocketDotNet.Types
         {
             JsonConvert.PopulateObject(settings.ToString(), this);
         }
-
-        /// <summary>
-        /// Convert to JSON object
-        /// </summary>
-        /// <returns></returns>
-        public JObject ToJSONOLD()
-        {
-            var obj = new JObject();
-            obj.Add("server", ServerAddress);
-            obj.Add("key", StreamKey);
-            obj.Add("use_auth", UseAuthentication);
-            obj.Add("username", AuthUsername);
-            obj.Add("password", AuthPassword);
-            return obj;
-        }
     }
 }

--- a/obs-websocket-dotnet/Types/CustomRTMPStreamingService.cs
+++ b/obs-websocket-dotnet/Types/CustomRTMPStreamingService.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Custom RTMP settings (fully customizable RTMP credentials)
+    /// </summary>
+    public class CustomRTMPStreamingService
+    {
+        /// <summary>
+        /// RTMP server URL
+        /// </summary>
+        [JsonProperty(PropertyName = "server")]
+        public string ServerAddress;
+
+        /// <summary>
+        /// RTMP stream key (URL suffix)
+        /// </summary>
+        [JsonProperty(PropertyName = "key")]
+        public string StreamKey;
+
+        /// <summary>
+        /// Tell OBS' RTMP client to authenticate to the server
+        /// </summary>
+        [JsonProperty(PropertyName = "use_auth")]
+        public bool UseAuthentication;
+
+        /// <summary>
+        /// Username used if authentication is enabled
+        /// </summary>
+        [JsonProperty(PropertyName = "username")]
+        public string AuthUsername;
+
+        /// <summary>
+        /// Password used if authentication is enabled
+        /// </summary>
+        [JsonProperty(PropertyName = "password")]
+        public string AuthPassword;
+
+        /// <summary>
+        /// Construct object from data provided by <see cref="StreamingService.Settings"/>
+        /// </summary>
+        /// <param name="settings"></param>
+        public CustomRTMPStreamingService(JObject settings)
+        {
+            JsonConvert.PopulateObject(settings.ToString(), this);
+        }
+
+        /// <summary>
+        /// Convert to JSON object
+        /// </summary>
+        /// <returns></returns>
+        public JObject ToJSONOLD()
+        {
+            var obj = new JObject();
+            obj.Add("server", ServerAddress);
+            obj.Add("key", StreamKey);
+            obj.Add("use_auth", UseAuthentication);
+            obj.Add("username", AuthUsername);
+            obj.Add("password", AuthPassword);
+            return obj;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/CustomRTMPStreamingService.cs
+++ b/obs-websocket-dotnet/Types/CustomRTMPStreamingService.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/FilterMovementType.cs
+++ b/obs-websocket-dotnet/Types/FilterMovementType.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Direction to move filters
+    /// </summary>
+    public enum FilterMovementType
+    {
+        /// <summary>
+        /// Up one
+        /// </summary>
+        UP,
+        /// <summary>
+        /// Down one
+        /// </summary>
+        DOWN,
+        /// <summary>
+        /// Top of the list
+        /// </summary>
+        TOP,
+        /// <summary>
+        /// Bottom of the list
+        /// </summary>
+        BOTTOM
+    }
+}

--- a/obs-websocket-dotnet/Types/FilterReorderItem.cs
+++ b/obs-websocket-dotnet/Types/FilterReorderItem.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/FilterReorderItem.cs
+++ b/obs-websocket-dotnet/Types/FilterReorderItem.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Filter list item
+    /// </summary>
+    public class FilterReorderItem
+    {
+        /// <summary>
+        /// Name of filter
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string Name { set; get; }
+
+        /// <summary>
+        /// Type of filter
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/FilterSettings.cs
+++ b/obs-websocket-dotnet/Types/FilterSettings.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Filter settings
+    /// </summary>
+    public class FilterSettings
+    {
+        /// <summary>
+        /// Name of the filter
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string Name { set; get; }
+
+        /// <summary>
+        /// Type of the specified filter
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { set; get; }
+
+        /// <summary>
+        /// Settings for the filter
+        /// </summary>
+        [JsonProperty(PropertyName = "settings")]
+        public JObject Settings { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/FilterSettings.cs
+++ b/obs-websocket-dotnet/Types/FilterSettings.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/GetSceneListInfo.cs
+++ b/obs-websocket-dotnet/Types/GetSceneListInfo.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Get Scene Info response
+    /// </summary>
+    public class GetSceneListInfo
+    {
+        /// <summary>
+        /// Name of the currently active scene
+        /// </summary>
+        [JsonProperty(PropertyName = "current-scene")]
+        public string CurrentScene { set; get; }
+
+        /// <summary>
+        /// Ordered list of the current profile's scenes
+        /// </summary>
+        [JsonProperty(PropertyName = "scenes")]
+        public List<OBSScene> Scenes { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/GetTransitionListInfo.cs
+++ b/obs-websocket-dotnet/Types/GetTransitionListInfo.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Response from <see cref="OBSWebsocket.GetTransitionList"/>
+    /// </summary>
+    public class GetTransitionListInfo
+    {
+        /// <summary>
+        /// Name of the currently active transition
+        /// </summary>
+        [JsonProperty(PropertyName = "current-transition")]
+        public string CurrentTransition { set; get; }
+
+        /// <summary>
+        /// List of transitions.
+        /// </summary>
+        [JsonProperty(PropertyName = "transitions")]
+        public List<TransitionSettings> Transitions { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/Heartbeat.cs
+++ b/obs-websocket-dotnet/Types/Heartbeat.cs
@@ -1,0 +1,97 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Heartbeat response
+    /// </summary>
+    public class Heartbeat
+    {
+        /// <summary>
+        /// Create a heartbeat
+        /// </summary>
+        /// <param name="body"></param>
+        public Heartbeat(JObject body)
+        {
+            JsonConvert.PopulateObject(body.ToString(), this);
+        }
+
+        /// <summary>         
+        /// Toggles between every JSON message as an "I am alive" indicator.         
+        /// </summary>
+        [JsonProperty(PropertyName = "pulse")]
+        public bool Pulse { set; get; }
+
+        /// <summary>         
+        /// Current active profile.         
+        /// </summary>
+        [JsonProperty(PropertyName = "current-profile")]
+        public string CurrentProfile { set; get; }
+
+        /// <summary>         
+        /// Current active scene.         
+        /// </summary>
+        [JsonProperty(PropertyName = "current-scene")]
+        public string CurrentScene { set; get; }
+
+        /// <summary>         
+        /// Current streaming state.         
+        /// </summary>
+        [JsonProperty(PropertyName = "streaming")]
+        public bool Streaming { set; get; }
+
+        /// <summary>         
+        /// Total time (in seconds) since the stream started.         
+        /// </summary>
+        [JsonProperty(PropertyName = "total-stream-time")]
+        public int totalStreamTime { set; get; }
+
+        /// <summary>         
+        /// Total bytes sent since the stream started.         
+        /// </summary>
+        [JsonProperty(PropertyName = "total-stream-bytes")]
+        public ulong  TotalStreamBytes { set; get; }
+
+        /// <summary>         
+        /// Total frames streamed since the stream started.         
+        /// </summary>
+        [JsonProperty(PropertyName = "total-stream-frames")]
+        public ulong TotalStreamFrames { set; get; }
+
+        /// <summary>         
+        /// Current recording state.         
+        /// </summary>
+        [JsonProperty(PropertyName = "recording")]
+        public bool Recording { set; get; }
+
+        /// <summary>         
+        /// Total time (in seconds) since recording started.         
+        /// </summary>
+        [JsonProperty(PropertyName = "total-record-time")]
+        public int TotalRecordTime { set; get; }
+
+        /// <summary>         
+        /// Total bytes recorded since the recording started.         
+        /// </summary>
+        [JsonProperty(PropertyName = "total-record-bytes")]
+        public int TotalTecordBytes { set; get; }
+
+        /// <summary>         
+        /// Total frames recorded since the recording started.         
+        /// </summary>
+        [JsonProperty(PropertyName = "total-record-frames")]
+        public int TotalRecordFrames { set; get; }
+
+        /// <summary>         
+        /// OBS Stats         
+        /// </summary>
+        [JsonProperty(PropertyName = "stats")]
+        public OBSStats Stats { set; get; }
+
+    }
+}

--- a/obs-websocket-dotnet/Types/Heartbeat.cs
+++ b/obs-websocket-dotnet/Types/Heartbeat.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -21,77 +17,76 @@ namespace OBSWebsocketDotNet.Types
             JsonConvert.PopulateObject(body.ToString(), this);
         }
 
-        /// <summary>         
-        /// Toggles between every JSON message as an "I am alive" indicator.         
+        /// <summary>
+        /// Toggles between every JSON message as an "I am alive" indicator.
         /// </summary>
         [JsonProperty(PropertyName = "pulse")]
         public bool Pulse { set; get; }
 
-        /// <summary>         
-        /// Current active profile.         
+        /// <summary>
+        /// Current active profile.
         /// </summary>
         [JsonProperty(PropertyName = "current-profile")]
         public string CurrentProfile { set; get; }
 
-        /// <summary>         
-        /// Current active scene.         
+        /// <summary>
+        /// Current active scene.
         /// </summary>
         [JsonProperty(PropertyName = "current-scene")]
         public string CurrentScene { set; get; }
 
-        /// <summary>         
-        /// Current streaming state.         
+        /// <summary>
+        /// Current streaming state.
         /// </summary>
         [JsonProperty(PropertyName = "streaming")]
         public bool Streaming { set; get; }
 
-        /// <summary>         
-        /// Total time (in seconds) since the stream started.         
+        /// <summary>
+        /// Total time (in seconds) since the stream started.
         /// </summary>
         [JsonProperty(PropertyName = "total-stream-time")]
         public int totalStreamTime { set; get; }
 
-        /// <summary>         
-        /// Total bytes sent since the stream started.         
+        /// <summary>
+        /// Total bytes sent since the stream started.
         /// </summary>
         [JsonProperty(PropertyName = "total-stream-bytes")]
-        public ulong  TotalStreamBytes { set; get; }
+        public ulong TotalStreamBytes { set; get; }
 
-        /// <summary>         
-        /// Total frames streamed since the stream started.         
+        /// <summary>
+        /// Total frames streamed since the stream started.
         /// </summary>
         [JsonProperty(PropertyName = "total-stream-frames")]
         public ulong TotalStreamFrames { set; get; }
 
-        /// <summary>         
-        /// Current recording state.         
+        /// <summary>
+        /// Current recording state.
         /// </summary>
         [JsonProperty(PropertyName = "recording")]
         public bool Recording { set; get; }
 
-        /// <summary>         
-        /// Total time (in seconds) since recording started.         
+        /// <summary>
+        /// Total time (in seconds) since recording started.
         /// </summary>
         [JsonProperty(PropertyName = "total-record-time")]
         public int TotalRecordTime { set; get; }
 
-        /// <summary>         
-        /// Total bytes recorded since the recording started.         
+        /// <summary>
+        /// Total bytes recorded since the recording started.
         /// </summary>
         [JsonProperty(PropertyName = "total-record-bytes")]
         public int TotalTecordBytes { set; get; }
 
-        /// <summary>         
-        /// Total frames recorded since the recording started.         
+        /// <summary>
+        /// Total frames recorded since the recording started.
         /// </summary>
         [JsonProperty(PropertyName = "total-record-frames")]
         public int TotalRecordFrames { set; get; }
 
-        /// <summary>         
-        /// OBS Stats         
+        /// <summary>
+        /// OBS Stats
         /// </summary>
         [JsonProperty(PropertyName = "stats")]
         public OBSStats Stats { set; get; }
-
     }
 }

--- a/obs-websocket-dotnet/Types/OBSAuthInfo.cs
+++ b/obs-websocket-dotnet/Types/OBSAuthInfo.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Data required by authentication
+    /// </summary>
+    public class OBSAuthInfo
+    {
+        /// <summary>
+        /// True if authentication is required, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "authRequired")]
+        public readonly bool AuthRequired;
+
+        /// <summary>
+        /// Authentication challenge
+        /// </summary>
+        [JsonProperty(PropertyName = "challenge")]
+        public readonly string Challenge;
+
+        /// <summary>
+        /// Password salt
+        /// </summary>
+        [JsonProperty(PropertyName = "salt")]
+        public readonly string PasswordSalt;
+
+        /// <summary>
+        /// Builds the object from JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public OBSAuthInfo(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/OBSAuthInfo.cs
+++ b/obs-websocket-dotnet/Types/OBSAuthInfo.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/OBSScene.cs
+++ b/obs-websocket-dotnet/Types/OBSScene.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Describes a scene in OBS, along with its items
+    /// </summary>
+    public class OBSScene
+    {
+        /// <summary>
+        /// OBS Scene name
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string Name;
+
+        /// <summary>
+        /// Scene item list
+        /// </summary>
+        [JsonProperty(PropertyName = "source")]
+        public List<SceneItem> Items;
+
+        /// <summary>
+        /// Builds the object from the JSON description
+        /// </summary>
+        /// <param name="data">JSON scene description as a <see cref="JObject" /></param>
+        public OBSScene(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/OBSScene.cs
+++ b/obs-websocket-dotnet/Types/OBSScene.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -21,7 +18,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Scene item list
         /// </summary>
-        [JsonProperty(PropertyName = "source")]
+        [JsonProperty(PropertyName = "sources")]
         public List<SceneItem> Items;
 
         /// <summary>
@@ -30,7 +27,17 @@ namespace OBSWebsocketDotNet.Types
         /// <param name="data">JSON scene description as a <see cref="JObject" /></param>
         public OBSScene(JObject data)
         {
-            JsonConvert.PopulateObject(data.ToString(), this);
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.ObjectCreationHandling = ObjectCreationHandling.Auto;
+            settings.NullValueHandling = NullValueHandling.Include;
+            JsonConvert.PopulateObject(data.ToString(), this, settings);
+        }
+
+        /// <summary>
+        /// Constructor used for jsonconverter
+        /// </summary>
+        public OBSScene()
+        {
         }
     }
 }

--- a/obs-websocket-dotnet/Types/OBSStats.cs
+++ b/obs-websocket-dotnet/Types/OBSStats.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -11,48 +7,56 @@ namespace OBSWebsocketDotNet.Types
     /// </summary>
     public class OBSStats
     {
-        /// <summary>         
-        /// Current framerate.         
+        /// <summary>
+        /// Current framerate.
         /// </summary>
         [JsonProperty(PropertyName = "fps")]
         public double FPS { set; get; }
-        /// <summary>         
-        /// Number of frames rendered         
+
+        /// <summary>
+        /// Number of frames rendered
         /// </summary>
         [JsonProperty(PropertyName = "render-total-frames")]
         public int RenderTotalFrames { set; get; }
-        /// <summary>         
-        /// Number of frames missed due to rendering lag         
+
+        /// <summary>
+        /// Number of frames missed due to rendering lag
         /// </summary>
         [JsonProperty(PropertyName = "render-missed-frames")]
         public int RenderMissedFrames { set; get; }
-        /// <summary>         
-        /// Number of frames outputted         
+
+        /// <summary>
+        /// Number of frames outputted
         /// </summary>
         [JsonProperty(PropertyName = "output-total-frames")]
         public int OutputTotalFrames { set; get; }
-        /// <summary>         
-        /// Number of frames skipped due to encoding lag         
+
+        /// <summary>
+        /// Number of frames skipped due to encoding lag
         /// </summary>
         [JsonProperty(PropertyName = "output-skipped-frames")]
         public int OutputSkippedFrames { set; get; }
-        /// <summary>         
-        /// Average frame render time (in milliseconds)         
+
+        /// <summary>
+        /// Average frame render time (in milliseconds)
         /// </summary>
         [JsonProperty(PropertyName = "average-frame-time")]
         public double AverageFrameTime { set; get; }
-        /// <summary>         
-        /// Current CPU usage (percentage)         
+
+        /// <summary>
+        /// Current CPU usage (percentage)
         /// </summary>
         [JsonProperty(PropertyName = "cpu-usage")]
         public double CpuUsage { set; get; }
-        /// <summary>         
-        /// Current RAM usage (in megabytes)         
+
+        /// <summary>
+        /// Current RAM usage (in megabytes)
         /// </summary>
         [JsonProperty(PropertyName = "memory-usage")]
         public double MemoryUsage { set; get; }
-        /// <summary>         
-        /// Free recording disk space (in megabytes)         
+
+        /// <summary>
+        /// Free recording disk space (in megabytes)
         /// </summary>
         [JsonProperty(PropertyName = "free-disk-space")]
         public double FreeDiskSpace { set; get; }

--- a/obs-websocket-dotnet/Types/OBSStats.cs
+++ b/obs-websocket-dotnet/Types/OBSStats.cs
@@ -1,0 +1,60 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// OBS Stats
+    /// </summary>
+    public class OBSStats
+    {
+        /// <summary>         
+        /// Current framerate.         
+        /// </summary>
+        [JsonProperty(PropertyName = "fps")]
+        public double FPS { set; get; }
+        /// <summary>         
+        /// Number of frames rendered         
+        /// </summary>
+        [JsonProperty(PropertyName = "render-total-frames")]
+        public int RenderTotalFrames { set; get; }
+        /// <summary>         
+        /// Number of frames missed due to rendering lag         
+        /// </summary>
+        [JsonProperty(PropertyName = "render-missed-frames")]
+        public int RenderMissedFrames { set; get; }
+        /// <summary>         
+        /// Number of frames outputted         
+        /// </summary>
+        [JsonProperty(PropertyName = "output-total-frames")]
+        public int OutputTotalFrames { set; get; }
+        /// <summary>         
+        /// Number of frames skipped due to encoding lag         
+        /// </summary>
+        [JsonProperty(PropertyName = "output-skipped-frames")]
+        public int OutputSkippedFrames { set; get; }
+        /// <summary>         
+        /// Average frame render time (in milliseconds)         
+        /// </summary>
+        [JsonProperty(PropertyName = "average-frame-time")]
+        public double AverageFrameTime { set; get; }
+        /// <summary>         
+        /// Current CPU usage (percentage)         
+        /// </summary>
+        [JsonProperty(PropertyName = "cpu-usage")]
+        public double CpuUsage { set; get; }
+        /// <summary>         
+        /// Current RAM usage (in megabytes)         
+        /// </summary>
+        [JsonProperty(PropertyName = "memory-usage")]
+        public double MemoryUsage { set; get; }
+        /// <summary>         
+        /// Free recording disk space (in megabytes)         
+        /// </summary>
+        [JsonProperty(PropertyName = "free-disk-space")]
+        public double FreeDiskSpace { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/OBSVersion.cs
+++ b/obs-websocket-dotnet/Types/OBSVersion.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -16,13 +12,25 @@ namespace OBSWebsocketDotNet.Types
         /// obs-websocket plugin version
         /// </summary>
         [JsonProperty(PropertyName = "obs-websocket-version")]
-        public readonly string PluginVersion;
+        public string PluginVersion { get; internal set; }
 
         /// <summary>
         /// OBS Studio version
         /// </summary>
         [JsonProperty(PropertyName = "obs-studio-version")]
-        public readonly string OBSStudioVersion;
+        public string OBSStudioVersion { get; internal set; }
+
+        /// <summary>
+        /// OBSRemote compatible API version.Fixed to 1.1 for retrocompatibility.
+        /// </summary>
+        [JsonProperty(PropertyName = "version")]
+        public double Version { internal set; get; }
+
+        /// <summary>
+        /// List of available request types, formatted as a comma-separated list string (e.g. : "Method1,Method2,Method3").
+        /// </summary>
+        [JsonProperty(PropertyName = "available-requests")]
+        public string AvailableRequests { get; internal set; }
 
         /// <summary>
         /// Builds the object from the JSON response body
@@ -32,5 +40,11 @@ namespace OBSWebsocketDotNet.Types
         {
             JsonConvert.PopulateObject(data.ToString(), this);
         }
+
+        /// <summary>
+        /// Empty constructor for jsonconvert
+        /// </summary>
+        public OBSVersion() { }
+
     }
 }

--- a/obs-websocket-dotnet/Types/OBSVersion.cs
+++ b/obs-websocket-dotnet/Types/OBSVersion.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Version info of the plugin, the API and OBS Studio
+    /// </summary>
+    public class OBSVersion
+    {
+        /// <summary>
+        /// obs-websocket plugin version
+        /// </summary>
+        [JsonProperty(PropertyName = "obs-websocket-version")]
+        public readonly string PluginVersion;
+
+        /// <summary>
+        /// OBS Studio version
+        /// </summary>
+        [JsonProperty(PropertyName = "obs-studio-version")]
+        public readonly string OBSStudioVersion;
+
+        /// <summary>
+        /// Builds the object from the JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public OBSVersion(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/OBSVideoInfo.cs
+++ b/obs-websocket-dotnet/Types/OBSVideoInfo.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Basic OBS video information
+    /// </summary>
+    public class OBSVideoInfo
+    {
+        /// <summary>
+        /// Base (canvas) width
+        /// </summary>
+        [JsonProperty(PropertyName = "baseWidth")]
+        public int BaseWidth { internal set; get; }
+
+        /// <summary>
+        /// Base (canvas) height
+        /// </summary>
+        [JsonProperty(PropertyName = "baseHeight")]
+        public int BaseHeight { internal set; get; }
+
+        /// <summary>
+        /// Output width
+        /// </summary>
+        [JsonProperty(PropertyName = "outputWidth")]
+        public int OutputWidth { internal set; get; }
+
+        /// <summary>
+        /// Output height
+        /// </summary>
+        [JsonProperty(PropertyName = "outputHeight")]
+        public int OutputHeight { internal set; get; }
+
+        /// <summary>
+        /// Scaling method used if output size differs from base size
+        /// </summary>
+        [JsonProperty(PropertyName = "scaleType")]
+        public string ScaleType { internal set; get; }
+
+        /// <summary>
+        /// Frames rendered per second
+        /// </summary>
+        [JsonProperty(PropertyName = "fps")]
+        public double FPS { internal set; get; }
+
+        /// <summary>
+        /// Video color format
+        /// </summary>
+        [JsonProperty(PropertyName = "videoFormat")]
+        public string VideoFormat { internal set; get; }
+
+        /// <summary>
+        /// Color space for YUV
+        /// </summary>
+        [JsonProperty(PropertyName = "colorSpace")]
+        public string ColorSpace { internal set; get; }
+
+        /// <summary>
+        /// Color range (full or partial)
+        /// </summary>
+        [JsonProperty(PropertyName = "colorRange")]
+        public string ColorRange { internal set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/OutputState.cs
+++ b/obs-websocket-dotnet/Types/OutputState.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace OBSWebsocketDotNet.Types
+﻿namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
     /// Describes the state of an output (streaming or recording)

--- a/obs-websocket-dotnet/Types/OutputState.cs
+++ b/obs-websocket-dotnet/Types/OutputState.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Describes the state of an output (streaming or recording)
+    /// </summary>
+    public enum OutputState
+    {
+        /// <summary>
+        /// The output is initializing and doesn't produces frames yet
+        /// </summary>
+        Starting,
+
+        /// <summary>
+        /// The output is running and produces frames
+        /// </summary>
+        Started,
+
+        /// <summary>
+        /// The output is stopping and sends the last remaining frames in its buffer
+        /// </summary>
+        Stopping,
+
+        /// <summary>
+        /// The output is completely stopped
+        /// </summary>
+        Stopped
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItem.cs
+++ b/obs-websocket-dotnet/Types/SceneItem.cs
@@ -42,7 +42,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Item source width, without scaling and transforms applied
         /// </summary>
-        [JsonProperty(PropertyName = "soruce_cx")]
+        [JsonProperty(PropertyName = "source_cx")]
         public int SourceWidth;
 
         /// <summary>

--- a/obs-websocket-dotnet/Types/SceneItem.cs
+++ b/obs-websocket-dotnet/Types/SceneItem.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -105,5 +102,11 @@ namespace OBSWebsocketDotNet.Types
             JsonConvert.PopulateObject(data.ToString(), this);
         }
 
+        /// <summary>
+        /// Empty constructor for JSON deserialization
+        /// </summary>
+        public SceneItem()
+        {
+        }
     }
 }

--- a/obs-websocket-dotnet/Types/SceneItem.cs
+++ b/obs-websocket-dotnet/Types/SceneItem.cs
@@ -1,0 +1,109 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Describes a scene item in an OBS scene
+    /// </summary>
+    public class SceneItem
+    {
+        /// <summary>
+        /// Source name
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string SourceName;
+
+        /// <summary>
+        /// Source type. Value is one of the following: "input", "filter", "transition", "scene" or "unknown"
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public string InternalType;
+
+        /// <summary>
+        /// Source audio volume
+        /// </summary>
+        [JsonProperty(PropertyName = "volume")]
+        public float AudioVolume;
+
+        /// <summary>
+        /// Scene item horizontal position/offset
+        /// </summary>
+        [JsonProperty(PropertyName = "x")]
+        public float XPos;
+
+        /// <summary>
+        /// Scene item vertical position/offset
+        /// </summary>
+        [JsonProperty(PropertyName = "y")]
+        public float YPos;
+
+        /// <summary>
+        /// Item source width, without scaling and transforms applied
+        /// </summary>
+        [JsonProperty(PropertyName = "soruce_cx")]
+        public int SourceWidth;
+
+        /// <summary>
+        /// Item source height, without scaling and transforms applied
+        /// </summary>
+        [JsonProperty(PropertyName = "source_cy")]
+        public int SourceHeight;
+
+        /// <summary>
+        /// Item width
+        /// </summary>
+        [JsonProperty(PropertyName = "cx")]
+        public float Width;
+
+        /// <summary>
+        /// Item height
+        /// </summary>
+        [JsonProperty(PropertyName = "cy")]
+        public float Height;
+
+        /// <summary>
+        /// Whether or not this Scene Item is locked and can't be moved around
+        /// </summary>
+        [JsonProperty(PropertyName = "locked")]
+        public bool Locked { set; get; }
+
+        /// <summary>
+        /// Whether or not this Scene Item is set to "visible".
+        /// </summary>
+        [JsonProperty(PropertyName = "render")]
+        public bool Render { set; get; }
+
+        /// <summary>
+        /// Scene item ID
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public int ID { set; get; }
+
+        /// <summary>
+        /// Name of the item's parent (if this item belongs to a group)
+        /// </summary>
+        [JsonProperty(PropertyName = "parentGroupName")]
+        public string ParentGroupName { set; get; }
+
+        /// <summary>
+        /// Name of the item's parent (if this item belongs to a group)
+        /// </summary>
+        [JsonProperty(PropertyName = "groupChildren")]
+        public List<SceneItem> GroupChildren { set; get; }
+
+        /// <summary>
+        /// Builds the object from the JSON scene description
+        /// </summary>
+        /// <param name="data">JSON item description as a <see cref="JObject"/></param>
+        public SceneItem(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
@@ -11,7 +11,7 @@ namespace OBSWebsocketDotNet.Types
         /// Alignment of the bounding box
         /// </summary>
         [JsonProperty(PropertyName = "alignment")]
-        public int Alingnment { set; get; }
+        public int Alignnment { set; get; }
 
         /// <summary>
         /// Type of bounding box

--- a/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Information on scene item bounds
+    /// </summary>
+    public class SceneItemBoundsInfo
+    {
+        /// <summary>
+        /// Alignment of the bounding box
+        /// </summary>
+        [JsonProperty(PropertyName = "alignment")]
+        public int Alingnment { set; get; }
+
+        /// <summary>
+        /// Type of bounding box
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public SceneItemBoundsType Type { set; get; }
+
+        /// <summary>
+        /// Width of the bounding box
+        /// </summary>
+        [JsonProperty(PropertyName = "x")]
+        public double Width { set; get; }
+
+        /// <summary>
+        /// Height of the bounding box
+        /// </summary>
+        [JsonProperty(PropertyName = "y")]
+        public double Height { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -17,6 +18,7 @@ namespace OBSWebsocketDotNet.Types
         /// Type of bounding box
         /// </summary>
         [JsonProperty(PropertyName = "type")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public SceneItemBoundsType Type { set; get; }
 
         /// <summary>

--- a/obs-websocket-dotnet/Types/SceneItemBoundsType.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Types of bounding boxes for scene items
+    /// </summary>
+    public enum SceneItemBoundsType
+    {
+        OBS_BOUNDS_STRETCH,
+        OBS_BOUNDS_SCALE_INNER,
+        OBS_BOUNDS_SCALE_OUTER,
+        OBS_BOUNDS_SCALE_TO_WIDTH,
+        OBS_BOUNDS_SCALE_TO_HEIGHT,
+        OBS_BOUNDS_MAX_ONLY,
+        OBS_BOUNDS_NONE
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemBoundsType.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsType.cs
@@ -5,12 +5,33 @@
     /// </summary>
     public enum SceneItemBoundsType
     {
+        /// <summary>
+        /// Stretch
+        /// </summary>
         OBS_BOUNDS_STRETCH,
+        /// <summary>
+        /// Inner scale
+        /// </summary>
         OBS_BOUNDS_SCALE_INNER,
+        /// <summary>
+        /// Outer scale
+        /// </summary>
         OBS_BOUNDS_SCALE_OUTER,
+        /// <summary>
+        /// Scale to width
+        /// </summary>
         OBS_BOUNDS_SCALE_TO_WIDTH,
+        /// <summary>
+        /// Scale to height
+        /// </summary>
         OBS_BOUNDS_SCALE_TO_HEIGHT,
+        /// <summary>
+        /// Max only
+        /// </summary>
         OBS_BOUNDS_MAX_ONLY,
+        /// <summary>
+        /// No bounds
+        /// </summary>
         OBS_BOUNDS_NONE
     }
 }

--- a/obs-websocket-dotnet/Types/SceneItemBoundsType.cs
+++ b/obs-websocket-dotnet/Types/SceneItemBoundsType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace OBSWebsocketDotNet.Types
+﻿namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
     /// Types of bounding boxes for scene items

--- a/obs-websocket-dotnet/Types/SceneItemCropInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemCropInfo.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/SceneItemCropInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemCropInfo.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Crop coordinates for a scene item
+    /// </summary>
+    public struct SceneItemCropInfo
+    {
+        /// <summary>
+        /// Top crop (in pixels)
+        /// </summary>
+        [JsonProperty(PropertyName = "top")]
+        public int Top;
+
+        /// <summary>
+        /// Bottom crop (in pixels)
+        /// </summary>
+        [JsonProperty(PropertyName = "bottom")]
+        public int Bottom;
+
+        /// <summary>
+        /// Left crop (in pixels)
+        /// </summary>
+        [JsonProperty(PropertyName = "left")]
+        public int Left;
+
+        /// <summary>
+        /// Right crop (in pixels)
+        /// </summary>
+        [JsonProperty(PropertyName = "right")]
+        public int Right;
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemCropInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemCropInfo.cs
@@ -5,7 +5,7 @@ namespace OBSWebsocketDotNet.Types
     /// <summary>
     /// Crop coordinates for a scene item
     /// </summary>
-    public struct SceneItemCropInfo
+    public class SceneItemCropInfo
     {
         /// <summary>
         /// Top crop (in pixels)

--- a/obs-websocket-dotnet/Types/SceneItemPointInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemPointInfo.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Scene item point information
+    /// </summary>
+    public class SceneItemPointInfo
+    {
+
+        /// <summary>
+        /// The x-scale factor of the scene item
+        /// </summary>
+        [JsonProperty(PropertyName = "x")]
+        public double X { get; set; }
+
+        /// <summary>
+        /// The y-scale factor of the scene item
+        /// </summary>
+        [JsonProperty(PropertyName = "y")]
+        public double Y { get; set; }
+
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemPointInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemPointInfo.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -11,7 +7,6 @@ namespace OBSWebsocketDotNet.Types
     /// </summary>
     public class SceneItemPointInfo
     {
-
         /// <summary>
         /// The x-scale factor of the scene item
         /// </summary>
@@ -23,6 +18,5 @@ namespace OBSWebsocketDotNet.Types
         /// </summary>
         [JsonProperty(PropertyName = "y")]
         public double Y { get; set; }
-
     }
 }

--- a/obs-websocket-dotnet/Types/SceneItemPositionInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemPositionInfo.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/SceneItemPositionInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemPositionInfo.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Scene item position information
+    /// </summary>
+    public class SceneItemPositionInfo
+    {
+        /// <summary>
+        /// The point on the scene item that the item is manipulated from
+        /// </summary>
+        [JsonProperty(PropertyName = "alignment")]
+        public int Alingnment { set; get; }
+
+        /// <summary>
+        /// The x position of the scene item from the left
+        /// </summary>
+        [JsonProperty(PropertyName = "x")]
+        public double X { set; get; }
+
+        /// <summary>
+        /// The y position of the scene item from the top
+        /// </summary>
+        [JsonProperty(PropertyName = "y")]
+        public double Y { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemProperties.cs
+++ b/obs-websocket-dotnet/Types/SceneItemProperties.cs
@@ -55,6 +55,12 @@ namespace OBSWebsocketDotNet.Types
         public string ItemName { set; get; }
 
         /// <summary>
+        /// Scene item name, <i>populated from GetSceneItemProperites only</i>
+        /// </summary>
+        [JsonProperty(PropertyName = "item")]
+        public string Item { set; get; }
+
+        /// <summary>
         /// Scene item height (base source height multiplied by the vertical scaling factor)
         /// </summary>
         [JsonProperty(PropertyName = "height")]

--- a/obs-websocket-dotnet/Types/SceneItemStub.cs
+++ b/obs-websocket-dotnet/Types/SceneItemStub.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Stub for scene item that only contains the name or ID of an item
+    /// </summary>
+    public class SceneItemStub
+    {
+        /// <summary>
+        /// Source name
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string SourceName;
+
+        /// <summary>
+        /// Scene item ID
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public int ID { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemTransform.cs
+++ b/obs-websocket-dotnet/Types/SceneItemTransform.cs
@@ -1,81 +1,99 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public class SceneItemTransform
+    public class SceneItemProperties
     {
         /// <summary>
         /// Initialize the scene item transform
         /// </summary>
         /// <param name="body"></param>
-        public SceneItemTransform(JObject body)
+        public SceneItemProperties(JObject body)
         {
             JsonConvert.PopulateObject(body.ToString(), this);
         }
 
         /// <summary>
+        /// Constructor used for json converter
+        /// </summary>
+        public SceneItemProperties()
+        {
+        }
+
+        /// <summary>
         /// Crop Information
         /// </summary>
+        [JsonProperty(PropertyName = "crop")]
         public SceneItemCropInfo Crop { set; get; }
 
         /// <summary>
         /// Bounds Information
         /// </summary>
+        [JsonProperty(PropertyName = "bounds")]
         public SceneItemBoundsInfo Bounds { set; get; }
 
         /// <summary>
         /// Scale Information
         /// </summary>
+        [JsonProperty(PropertyName = "scale")]
         public SceneItemPointInfo Scale { set; get; }
 
         /// <summary>
-        /// 
+        /// Position of the item
         /// </summary>
+        [JsonProperty(PropertyName = "position")]
         public SceneItemPositionInfo Position { set; get; }
+
+        /// <summary>
+        /// Scene item name, <i>populated from GetSceneItemProperites only</i>
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string ItemName { set; get; }
 
         /// <summary>
         /// Scene item height (base source height multiplied by the vertical scaling factor)
         /// </summary>
+        [JsonProperty(PropertyName = "height")]
         public double Height { set; get; }
-
 
         /// <summary>
         /// Scene item width (base source width multiplied by the horizontal scaling factor)
         /// </summary>
+        [JsonProperty(PropertyName = "width")]
         public double Width { set; get; }
 
         /// <summary>
         /// If the scene item is locked in position
         /// </summary>
+        [JsonProperty(PropertyName = "locked")]
         public bool Locked { set; get; }
 
         /// <summary>
         /// If the scene item is visible
         /// </summary>
+        [JsonProperty(PropertyName = "visible")]
         public bool Visible { set; get; }
 
         /// <summary>
         /// Base height (without scaling) of the source
         /// </summary>
+        [JsonProperty(PropertyName = "sourceHeight")]
         public int SourceHeight { set; get; }
 
         /// <summary>
         /// Base width (without scaling) of the source
         /// </summary>
+        [JsonProperty(PropertyName = "sourceWidth")]
         public int SourceWidth { set; get; }
 
         /// <summary>
         /// The clockwise rotation of the scene item in degrees around the point of alignment.
         /// </summary>
+        [JsonProperty(PropertyName = "rotation")]
         public double Rotation { set; get; }
-
     }
 }

--- a/obs-websocket-dotnet/Types/SceneItemTransform.cs
+++ b/obs-websocket-dotnet/Types/SceneItemTransform.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class SceneItemTransform
+    {
+        /// <summary>
+        /// Initialize the scene item transform
+        /// </summary>
+        /// <param name="body"></param>
+        public SceneItemTransform(JObject body)
+        {
+            JsonConvert.PopulateObject(body.ToString(), this);
+        }
+
+        /// <summary>
+        /// Crop Information
+        /// </summary>
+        public SceneItemCropInfo Crop { set; get; }
+
+        /// <summary>
+        /// Bounds Information
+        /// </summary>
+        public SceneItemBoundsInfo Bounds { set; get; }
+
+        /// <summary>
+        /// Scale Information
+        /// </summary>
+        public SceneItemPointInfo Scale { set; get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public SceneItemPositionInfo Position { set; get; }
+
+        /// <summary>
+        /// Scene item height (base source height multiplied by the vertical scaling factor)
+        /// </summary>
+        public double Height { set; get; }
+
+
+        /// <summary>
+        /// Scene item width (base source width multiplied by the horizontal scaling factor)
+        /// </summary>
+        public double Width { set; get; }
+
+        /// <summary>
+        /// If the scene item is locked in position
+        /// </summary>
+        public bool Locked { set; get; }
+
+        /// <summary>
+        /// If the scene item is visible
+        /// </summary>
+        public bool Visible { set; get; }
+
+        /// <summary>
+        /// Base height (without scaling) of the source
+        /// </summary>
+        public int SourceHeight { set; get; }
+
+        /// <summary>
+        /// Base width (without scaling) of the source
+        /// </summary>
+        public int SourceWidth { set; get; }
+
+        /// <summary>
+        /// The clockwise rotation of the scene item in degrees around the point of alignment.
+        /// </summary>
+        public double Rotation { set; get; }
+
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemTransformInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemTransformInfo.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Scene transformation information from an event
+    /// </summary>
+    public class SceneItemTransformInfo
+    {
+        /// <summary>
+        /// Name of the scene
+        /// </summary>
+        [JsonProperty(PropertyName = "scene-name")]
+        public string SceneName { set; get; }
+
+        /// <summary>
+        /// Name of the item in the scene
+        /// </summary>
+        [JsonProperty(PropertyName = "item-name")]
+        public string ItemName { set; get; }
+
+        /// <summary>
+        /// Scene Item ID
+        /// </summary>
+        [JsonProperty(PropertyName = "item-id")]
+        public string ItemID { set; get; }
+
+        /// <summary>
+        /// Scene item transform properties
+        /// </summary>
+        [JsonProperty(PropertyName = "transform")]
+        public SceneItemProperties Transform { set; get; }
+
+        /// <summary>
+        /// Initialize the scene item transform
+        /// </summary>
+        /// <param name="body"></param>
+        public SceneItemTransformInfo(JObject body)
+        {
+            JsonConvert.PopulateObject(body.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/SceneItemTransformInfo.cs
+++ b/obs-websocket-dotnet/Types/SceneItemTransformInfo.cs
@@ -12,25 +12,25 @@ namespace OBSWebsocketDotNet.Types
         /// Name of the scene
         /// </summary>
         [JsonProperty(PropertyName = "scene-name")]
-        public string SceneName { set; get; }
+        public string SceneName { internal set; get; }
 
         /// <summary>
         /// Name of the item in the scene
         /// </summary>
         [JsonProperty(PropertyName = "item-name")]
-        public string ItemName { set; get; }
+        public string ItemName { internal set; get; }
 
         /// <summary>
         /// Scene Item ID
         /// </summary>
         [JsonProperty(PropertyName = "item-id")]
-        public string ItemID { set; get; }
+        public string ItemID { internal set; get; }
 
         /// <summary>
         /// Scene item transform properties
         /// </summary>
         [JsonProperty(PropertyName = "transform")]
-        public SceneItemProperties Transform { set; get; }
+        public SceneItemProperties Transform { internal set; get; }
 
         /// <summary>
         /// Initialize the scene item transform

--- a/obs-websocket-dotnet/Types/SourceInfo.cs
+++ b/obs-websocket-dotnet/Types/SourceInfo.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Source information returned by GetSourcesList
+    /// </summary>
+    public class SourceInfo
+    {
+        /// <summary>
+        /// Name of the source
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public string Name { set; get; }
+
+        /// <summary>
+        /// Non-unique source internal type(a.k.a type id)
+        /// </summary>
+        [JsonProperty(PropertyName = "typeId")]
+        public string TypeID { set; get; }
+
+        /// <summary>
+        /// Source type.Value is one of the following: "input", "filter", "transition", "scene" or "unknown"
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/SourceScreenshotResponse.cs
+++ b/obs-websocket-dotnet/Types/SourceScreenshotResponse.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
-    /// Respone from <see cref="OBSWebsocket.TakeSourceScreenshot"/>
+    /// Respone from <see cref="OBSWebsocket.TakeSourceScreenshot(string)"/>
     /// </summary>
     public class SourceScreenshotResponse
     {

--- a/obs-websocket-dotnet/Types/SourceScreenshotResponse.cs
+++ b/obs-websocket-dotnet/Types/SourceScreenshotResponse.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Respone from <see cref="OBSWebsocket.TakeSourceScreenshot"/>
+    /// </summary>
+    public class SourceScreenshotResponse
+    {
+        /// <summary>
+        /// Source name
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceName")]
+        public string SourceName { internal set; get; }
+
+        /// <summary>
+        /// Image Data URI(if embedPictureFormat was specified in the request)
+        /// </summary>
+        [JsonProperty(PropertyName = "img")]
+        public string ImageData { internal set; get; }
+
+        /// <summary>
+        /// Absolute path to the saved image file(if saveToFilePath was specified in the request)
+        /// </summary>
+        [JsonProperty(PropertyName = "imgFile")]
+        public string ImageFile { internal set; get; }
+    }
+
+}

--- a/obs-websocket-dotnet/Types/SourceSettings.cs
+++ b/obs-websocket-dotnet/Types/SourceSettings.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Settings for a source item
+    /// </summary>
+    public class SourceSettings
+    {
+        /// <summary>
+        /// Name of the source
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceName")]
+        public string sourceName { set; get; }
+
+
+        /// <summary>
+        /// Kind of source
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceKind")]
+        public string SourceKind { set; get; }
+
+
+        /// <summary>
+        /// Type of the specified source. Useful for type-checking if you expect a specific settings schema.
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceType")]
+        public string sourceType { set; get; }
+
+        /// <summary>
+        /// Settings for the source
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceSettings")]
+        public JObject sourceSettings { set; get; }
+
+
+        /// <summary>
+        /// Builds the object from the JSON data
+        /// </summary>
+        /// <param name="data">JSON item description as a <see cref="JObject"/></param>
+        public SourceSettings(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/SourceSettings.cs
+++ b/obs-websocket-dotnet/Types/SourceSettings.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -18,13 +14,11 @@ namespace OBSWebsocketDotNet.Types
         [JsonProperty(PropertyName = "sourceName")]
         public string sourceName { set; get; }
 
-
         /// <summary>
         /// Kind of source
         /// </summary>
         [JsonProperty(PropertyName = "sourceKind")]
         public string SourceKind { set; get; }
-
 
         /// <summary>
         /// Type of the specified source. Useful for type-checking if you expect a specific settings schema.
@@ -37,7 +31,6 @@ namespace OBSWebsocketDotNet.Types
         /// </summary>
         [JsonProperty(PropertyName = "sourceSettings")]
         public JObject sourceSettings { set; get; }
-
 
         /// <summary>
         /// Builds the object from the JSON data

--- a/obs-websocket-dotnet/Types/SourceType.cs
+++ b/obs-websocket-dotnet/Types/SourceType.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace OBSWebsocketDotNet.Types
 {
-    /// <sumoary>
+    /// <summary>
     /// OBS SOurce Type definitions
     /// </summary>
     public class SourceType

--- a/obs-websocket-dotnet/Types/SourceType.cs
+++ b/obs-websocket-dotnet/Types/SourceType.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <sumoary>
+    /// OBS SOurce Type definitions
+    /// </summary>
+    public class SourceType
+    {
+        /// <summary>
+        /// Non-unique internal source type ID
+        /// </summary>
+        [JsonProperty(PropertyName = "typeId")]
+        public string TypeID { set; get; }
+
+        /// <summary>
+        /// Display name of the source type
+        /// </summary>
+        [JsonProperty(PropertyName = "displayName")]
+        public string DisplayName { set; get; }
+
+        /// <summary>
+        /// Type.Value is one of the following: "input", "filter", "transition" or "other"
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { set; get; }
+
+        /// <summary>
+        /// Default settings of the source type
+        /// </summary>
+        [JsonProperty(PropertyName = "defaultSettings")]
+        public JObject DefaultSettings { set; get; }
+
+        /// <summary>
+        /// Source type capabilities
+        /// </summary>
+        [JsonProperty(PropertyName = "caps")]
+        public SourceTypeCapabilities Capabilities { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/SourceTypeCapabilities.cs
+++ b/obs-websocket-dotnet/Types/SourceTypeCapabilities.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Capabilities for a SourceType
+    /// </summary>
+    public class SourceTypeCapabilities
+    {
+        /// <summary>
+        /// True if source of this type provide frames asynchronously
+        /// </summary>
+        [JsonProperty(PropertyName = "isAsync")]
+        public bool IsAsync { set; get; }
+
+        /// <summary>
+        /// True if source of this type is deprecated
+        /// </summary>
+        [JsonProperty(PropertyName = "isDeprecated")]
+        public bool IsDeprecated { set; get; }
+
+        /// <summary>
+        /// True if sources of this type provide video
+        /// </summary>
+        [JsonProperty(PropertyName = "hasVideo")]
+        public bool HasVideo { set; get; }
+
+        /// <summary>
+        /// True if sources of this type provide audio
+        /// </summary>
+        [JsonProperty(PropertyName = "hasAudio")]
+        public bool HasAudio { set; get; }
+
+        /// <summary>
+        /// True if interaction with this sources of this type is possible
+        /// </summary>
+        [JsonProperty(PropertyName = "canInteract")]
+        public bool CanInteract { set; get; }
+
+        /// <summary>
+        /// True if sources of this type composite one or more sub-sources
+        /// </summary>
+        [JsonProperty(PropertyName = "isComposite")]
+        public bool IsComposite { set; get; }
+
+        /// <summary>
+        /// True if sources of this type should not be fully duplicated
+        /// </summary>
+        [JsonProperty(PropertyName = "doNotDuplicate")]
+        public bool DoNotDuplicate { set; get; }
+
+        /// <summary>
+        /// True if sources of this type may cause a feedback loop if it's audio is monitored and shouldn't be
+        /// </summary>
+        [JsonProperty(PropertyName = "doNotSelfMonitor")]
+        public bool DoNotSelfMonitor { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/StreamStatus.cs
+++ b/obs-websocket-dotnet/Types/StreamStatus.cs
@@ -12,55 +12,55 @@ namespace OBSWebsocketDotNet.Types
         /// True if streaming is started and running, false otherwise
         /// </summary>
         [JsonProperty(PropertyName = "streaming")]
-        public readonly bool Streaming;
+        public bool Streaming { internal set; get; }
 
         /// <summary>
         /// True if recording is started and running, false otherwise
         /// </summary>
         [JsonProperty(PropertyName = "recording")]
-        public readonly bool Recording;
+        public bool Recording { internal set; get; }
 
         /// <summary>
         /// Stream bitrate in bytes per second
         /// </summary>
         [JsonProperty(PropertyName = "bytes-per-sec")]
-        public readonly int BytesPerSec;
+        public int BytesPerSec { internal set; get; }
 
         /// <summary>
         /// Stream bitrate in kilobits per second
         /// </summary>
         [JsonProperty(PropertyName = "kbits-per-sec")]
-        public readonly int KbitsPerSec;
+        public int KbitsPerSec { internal set; get; }
 
         /// <summary>
         /// RTMP output strain
         /// </summary>
         [JsonProperty(PropertyName = "strain")]
-        public readonly float Strain;
+        public float Strain { internal set; get; }
 
         /// <summary>
         /// Total time since streaming start
         /// </summary>
         [JsonProperty(PropertyName = "total-stream-time")]
-        public readonly int TotalStreamTime;
+        public int TotalStreamTime { internal set; get; }
 
         /// <summary>
         /// Number of frames sent since streaming start
         /// </summary>
         [JsonProperty(PropertyName = "num-total-frames")]
-        public readonly int TotalFrames;
+        public int TotalFrames { internal set; get; }
 
         /// <summary>
         /// Overall number of frames dropped since streaming start
         /// </summary>
         [JsonProperty(PropertyName = "num-dropped-frames")]
-        public readonly int DroppedFrames;
+        public int DroppedFrames { internal set; get; }
 
         /// <summary>
         /// Current framerate in Frames Per Second
         /// </summary>
         [JsonProperty(PropertyName = "fps")]
-        public readonly float FPS;
+        public float FPS { internal set; get; }
 
         /// <summary>
         /// Builds the object from the JSON event body

--- a/obs-websocket-dotnet/Types/StreamStatus.cs
+++ b/obs-websocket-dotnet/Types/StreamStatus.cs
@@ -1,0 +1,78 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Data of a stream status update
+    /// </summary>
+    public class StreamStatus
+    {
+        /// <summary>
+        /// True if streaming is started and running, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "streaming")]
+        public readonly bool Streaming;
+
+        /// <summary>
+        /// True if recording is started and running, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "recording")]
+        public readonly bool Recording;
+
+        /// <summary>
+        /// Stream bitrate in bytes per second
+        /// </summary>
+        [JsonProperty(PropertyName = "bytes-per-sec")]
+        public readonly int BytesPerSec;
+
+        /// <summary>
+        /// Stream bitrate in kilobits per second
+        /// </summary>
+        [JsonProperty(PropertyName = "kbits-per-sec")]
+        public readonly int KbitsPerSec;
+
+        /// <summary>
+        /// RTMP output strain
+        /// </summary>
+        [JsonProperty(PropertyName = "strain")]
+        public readonly float Strain;
+
+        /// <summary>
+        /// Total time since streaming start
+        /// </summary>
+        [JsonProperty(PropertyName = "total-stream-time")]
+        public readonly int TotalStreamTime;
+
+        /// <summary>
+        /// Number of frames sent since streaming start
+        /// </summary>
+        [JsonProperty(PropertyName = "num-total-frames")]
+        public readonly int TotalFrames;
+
+        /// <summary>
+        /// Overall number of frames dropped since streaming start
+        /// </summary>
+        [JsonProperty(PropertyName = "num-dropped-frames")]
+        public readonly int DroppedFrames;
+
+        /// <summary>
+        /// Current framerate in Frames Per Second
+        /// </summary>
+        [JsonProperty(PropertyName = "fps")]
+        public readonly float FPS;
+
+        /// <summary>
+        /// Builds the object from the JSON event body
+        /// </summary>
+        /// <param name="data">JSON event body as a <see cref="JObject"/></param>
+        public StreamStatus(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/StreamStatus.cs
+++ b/obs-websocket-dotnet/Types/StreamStatus.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/StreamingService.cs
+++ b/obs-websocket-dotnet/Types/StreamingService.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/Types/StreamingService.cs
+++ b/obs-websocket-dotnet/Types/StreamingService.cs
@@ -11,12 +11,12 @@ namespace OBSWebsocketDotNet.Types
         /// Type of streaming service
         /// </summary>
         [JsonProperty(PropertyName = "type")]
-        public string Type;
+        public string Type { set; get; }
 
         /// <summary>
         /// Streaming service settings (JSON data)
         /// </summary>
         [JsonProperty(PropertyName = "source")]
-        public StreamingServiceSettings Settings;
+        public StreamingServiceSettings Settings { set; get; }
     }
 }

--- a/obs-websocket-dotnet/Types/StreamingService.cs
+++ b/obs-websocket-dotnet/Types/StreamingService.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Streaming settings
+    /// </summary>
+    public class StreamingService
+    {
+        /// <summary>
+        /// Type of streaming service
+        /// </summary>
+        [JsonProperty(PropertyName = "type")]
+        public string Type;
+
+        /// <summary>
+        /// Streaming service settings (JSON data)
+        /// </summary>
+        [JsonProperty(PropertyName = "source")]
+        public StreamingServiceSettings Settings;
+    }
+}

--- a/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
+++ b/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
@@ -36,6 +36,5 @@ namespace OBSWebsocketDotNet.Types
         /// </summary>
         [JsonProperty(PropertyName = "password")]
         public string Password { set; get; }
-
     }
 }

--- a/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
+++ b/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Streaming server settings
+    /// </summary>
+    public class StreamingServiceSettings
+    {
+        /// <summary>
+        /// The publish URL
+        /// </summary>
+        [JsonProperty(PropertyName = "server")]
+        public string Server { set; get; }
+
+        /// <summary>
+        /// The publish key of the stream
+        /// </summary>
+        [JsonProperty(PropertyName = "key")]
+        public string Key { set; get; }
+
+        /// <summary>
+        /// Indicates whether authentication should be used when connecting to the streaming server
+        /// </summary>
+        [JsonProperty(PropertyName = "use-auth")]
+        public bool UseAuth { set; get; }
+
+        /// <summary>
+        /// The username to use when accessing the streaming server. Only present if use-auth is true
+        /// </summary>
+        [JsonProperty(PropertyName = "username")]
+        public string Username { set; get; }
+
+        /// <summary>
+        /// The password to use when accessing the streaming server. Only present if use-auth is true
+        /// </summary>
+        [JsonProperty(PropertyName = "password")]
+        public string Password { set; get; }
+
+    }
+}

--- a/obs-websocket-dotnet/Types/TextGDIPlusFont.cs
+++ b/obs-websocket-dotnet/Types/TextGDIPlusFont.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Font information for a Text GDI+ source
+    /// </summary>
+    public class TextGDIPlusFont
+    {
+        /// <summary>
+        /// Font face.
+        /// </summary>
+        [JsonProperty(PropertyName = "face")]
+        public string Face { set; get; }
+
+        /// <summary>
+        /// Font text styling flag. Bold=1, Italic=2, Bold Italic=3, Underline=5, Strikeout=8
+        /// </summary>
+        [JsonProperty(PropertyName = "flags")]
+        public int Flags { set; get; }
+
+        /// <summary>
+        /// Font text size.
+        /// </summary>
+        [JsonProperty(PropertyName = "size")]
+        public int Size { set; get; }
+
+        /// <summary>
+        /// Font Style (unknown function).
+        /// </summary>
+        [JsonProperty(PropertyName = "style")]
+        public string Style { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/TextGDIPlusProperties.cs
+++ b/obs-websocket-dotnet/Types/TextGDIPlusProperties.cs
@@ -1,0 +1,154 @@
+﻿using Newtonsoft.Json;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Properties for a GDI+ Text source
+    /// </summary>
+    public class TextGDIPlusProperties
+    {
+        /// <summary>
+        /// Source name.
+        /// </summary>
+        [JsonProperty(PropertyName = "source")]
+        public string SourceName { set; get; }
+
+        /// <summary>
+        /// Text Alignment ("left", "center", "right").
+        /// </summary>
+        [JsonProperty(PropertyName = "align")]
+        public string Alignment { set; get; }
+
+        /// <summary>
+        /// Background color.
+        /// </summary>
+        [JsonProperty(PropertyName = "bk-color")]
+        public ulong BackgroundColor { set; get; }
+
+        /// <summary>
+        /// Background opacity (0-100).
+        /// </summary>
+        [JsonProperty(PropertyName = "bk-opacity")]
+        public int BackgroundOpacity { set; get; }
+
+        /// <summary>
+        /// Chat log.
+        /// </summary>
+        [JsonProperty(PropertyName = "chatlog")]
+        public bool IsChatLog { set; get; }
+
+        /// <summary>
+        /// Chat log lines.
+        /// </summary>
+        [JsonProperty(PropertyName = "chatlog_lines")]
+        public int ChatlogLines { set; get; }
+
+        /// <summary>
+        /// Text color.
+        /// </summary>
+        [JsonProperty(PropertyName = "color")]
+        public ulong TextColor { set; get; }
+
+        /// <summary>
+        /// Extents wrap.
+        /// </summary>
+        [JsonProperty(PropertyName = "extents")]
+        public bool HasExtents { set; get; }
+
+        /// <summary>
+        /// Extents cx.
+        /// </summary>
+        [JsonProperty(PropertyName = "extents_cx")]
+        public int Height { set; get; }
+
+        /// <summary>
+        /// Extents cy.
+        /// </summary>
+        [JsonProperty(PropertyName = "extents_cy")]
+        public int Width { set; get; }
+
+        /// <summary>
+        /// File path name.
+        /// </summary>
+        [JsonProperty(PropertyName = "file")]
+        public string Filename { set; get; }
+
+        /// <summary>
+        /// Read text from the specified file.
+        /// </summary>
+        [JsonProperty(PropertyName = "read_from_file")]
+        public bool IsReadFromFile { set; get; }
+
+        /// <summary>
+        /// Holds data for the font. Ex: "font": { "face": "Arial", "flags": 0, "size": 150, "style": "" }
+        /// </summary>
+        [JsonProperty(PropertyName = "font")]
+        public TextGDIPlusFont Font { set; get; }
+
+        /// <summary>
+        /// Gradient enabled.
+        /// </summary>
+        [JsonProperty(PropertyName = "gradient")]
+        public bool HasGradient { set; get; }
+
+        /// <summary>
+        /// Gradient color.
+        /// </summary>
+        [JsonProperty(PropertyName = "gradient_color")]
+        public ulong GradientColor { set; get; }
+
+        /// <summary>
+        /// Gradient direction.
+        /// </summary>
+        [JsonProperty(PropertyName = "gradient_dir")]
+        public float GradientDirection { set; get; }
+
+        /// <summary>
+        /// Gradient opacity (0-100).
+        /// </summary>
+        [JsonProperty(PropertyName = "gradient_opacity")]
+        public int GradientOpacity { set; get; }
+
+        /// <summary>
+        /// Outline.
+        /// </summary>
+        [JsonProperty(PropertyName = "outline")]
+        public bool HasOutline { set; get; }
+
+        /// <summary>
+        /// Outline color.
+        /// </summary>
+        [JsonProperty(PropertyName = "outline_color")]
+        public ulong OutlineColor { set; get; }
+
+        /// <summary>
+        /// Outline size.
+        /// </summary>
+        [JsonProperty(PropertyName = "outline_size")]
+        public int OutlineSize { set; get; }
+
+        /// <summary>
+        /// Outline opacity (0-100).
+        /// </summary>
+        [JsonProperty(PropertyName = "outline_opacity")]
+        public int OutlineOpacity { set; get; }
+
+        /// <summary>
+        /// Text content to be displayed.
+        /// </summary>
+        [JsonProperty(PropertyName = "text")]
+        public string Text { set; get; }
+
+        /// <summary>
+        /// Text vertical alignment ("top", "center", "bottom").
+        /// </summary>
+        [JsonProperty(PropertyName = "valign")]
+        public string VeritcalAslignment { set; get; }
+
+        /// <summary>
+        /// Vertical text enabled.
+        /// </summary>
+        [JsonProperty(PropertyName = "vertical")]
+        public bool IsVertical { set; get; }
+    }
+}

--- a/obs-websocket-dotnet/Types/TransitionSettings.cs
+++ b/obs-websocket-dotnet/Types/TransitionSettings.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Current transition settings
+    /// </summary>
+    public class TransitionSettings
+    {
+        /// <summary>
+        /// Transition name
+        /// </summary>
+        [JsonProperty(PropertyName = "name")]
+        public readonly string Name;
+
+        /// <summary>
+        /// Transition duration in milliseconds
+        /// </summary>
+        [JsonProperty(PropertyName = "duration")]
+        public readonly int Duration;
+
+        /// <summary>
+        /// Builds the object from the JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public TransitionSettings(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/TransitionSettings.cs
+++ b/obs-websocket-dotnet/Types/TransitionSettings.cs
@@ -12,13 +12,13 @@ namespace OBSWebsocketDotNet.Types
         /// Transition name
         /// </summary>
         [JsonProperty(PropertyName = "name")]
-        public readonly string Name;
+        public string Name { internal set; get; }
 
         /// <summary>
         /// Transition duration in milliseconds
         /// </summary>
         [JsonProperty(PropertyName = "duration")]
-        public readonly int Duration;
+        public int Duration { internal set; get; }
 
         /// <summary>
         /// Builds the object from the JSON response body

--- a/obs-websocket-dotnet/Types/TransitionSettings.cs
+++ b/obs-websocket-dotnet/Types/TransitionSettings.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -32,5 +28,13 @@ namespace OBSWebsocketDotNet.Types
         {
             JsonConvert.PopulateObject(data.ToString(), this);
         }
+
+        /// <summary>
+        /// Constructor for jsonconverter
+        /// </summary>
+        public TransitionSettings()
+        {
+        }
+
     }
 }

--- a/obs-websocket-dotnet/Types/VolumeInfo.cs
+++ b/obs-websocket-dotnet/Types/VolumeInfo.cs
@@ -12,13 +12,13 @@ namespace OBSWebsocketDotNet.Types
         /// Source volume in linear scale (0.0 to 1.0)
         /// </summary>
         [JsonProperty(PropertyName = "volume")]
-        public readonly float Volume;
+        public float Volume { internal set; get; }
 
         /// <summary>
         /// True if source is muted, false otherwise
         /// </summary>
         [JsonProperty(PropertyName = "muted")]
-        public readonly bool Muted;
+        public bool Muted { internal set; get; }
 
         /// <summary>
         /// Builds the object from the JSON response body

--- a/obs-websocket-dotnet/Types/VolumeInfo.cs
+++ b/obs-websocket-dotnet/Types/VolumeInfo.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Volume settings of an OBS source
+    /// </summary>
+    public class VolumeInfo
+    {
+        /// <summary>
+        /// Source volume in linear scale (0.0 to 1.0)
+        /// </summary>
+        [JsonProperty(PropertyName = "volume")]
+        public readonly float Volume;
+
+        /// <summary>
+        /// True if source is muted, false otherwise
+        /// </summary>
+        [JsonProperty(PropertyName = "muted")]
+        public readonly bool Muted;
+
+        /// <summary>
+        /// Builds the object from the JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public VolumeInfo(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/VolumeInfo.cs
+++ b/obs-websocket-dotnet/Types/VolumeInfo.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace OBSWebsocketDotNet.Types
 {

--- a/obs-websocket-dotnet/obs-websocket-dotnet.csproj
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.csproj
@@ -55,9 +55,36 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="OBSWebsocket_Requests.cs" />
+    <Compile Include="OutputStatus.cs" />
     <Compile Include="Types.cs" />
     <Compile Include="OBSWebsocket.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Types\AudioMixerChannel.cs" />
+    <Compile Include="Types\AudioMixersChangedInfo.cs" />
+    <Compile Include="Types\BrowserSourceProperties.cs" />
+    <Compile Include="Types\CommonRTMPStreamingService.cs" />
+    <Compile Include="Types\CustomRTMPStreamingService.cs" />
+    <Compile Include="Types\FilterReorderItem.cs" />
+    <Compile Include="Types\Heartbeat.cs" />
+    <Compile Include="Types\OBSScene.cs" />
+    <Compile Include="Types\OBSStats.cs" />
+    <Compile Include="Types\FilterSettings.cs" />
+    <Compile Include="Types\OBSAuthInfo.cs" />
+    <Compile Include="Types\OBSVersion.cs" />
+    <Compile Include="Types\OutputState.cs" />
+    <Compile Include="Types\SceneItem.cs" />
+    <Compile Include="Types\SceneItemBoundsInfo.cs" />
+    <Compile Include="Types\SceneItemBoundsType.cs" />
+    <Compile Include="Types\SceneItemCropInfo.cs" />
+    <Compile Include="Types\SceneItemPointInfo.cs" />
+    <Compile Include="Types\SceneItemPositionInfo.cs" />
+    <Compile Include="Types\SceneItemTransform.cs" />
+    <Compile Include="Types\SourceSettings.cs" />
+    <Compile Include="Types\StreamingService.cs" />
+    <Compile Include="Types\StreamingServiceSettings.cs" />
+    <Compile Include="Types\StreamStatus.cs" />
+    <Compile Include="Types\TransitionSettings.cs" />
+    <Compile Include="Types\VolumeInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="obs-websocket-dotnet.nuspec" />

--- a/obs-websocket-dotnet/obs-websocket-dotnet.csproj
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.csproj
@@ -65,12 +65,16 @@
     <Compile Include="Types\CommonRTMPStreamingService.cs" />
     <Compile Include="Types\CustomRTMPStreamingService.cs" />
     <Compile Include="Types\FilterReorderItem.cs" />
+    <Compile Include="Types\GetSceneListInfo.cs" />
+    <Compile Include="Types\GetTransitionListInfo.cs" />
     <Compile Include="Types\Heartbeat.cs" />
+    <Compile Include="Types\FilterMovementType.cs" />
     <Compile Include="Types\OBSScene.cs" />
     <Compile Include="Types\OBSStats.cs" />
     <Compile Include="Types\FilterSettings.cs" />
     <Compile Include="Types\OBSAuthInfo.cs" />
     <Compile Include="Types\OBSVersion.cs" />
+    <Compile Include="Types\OBSVideoInfo.cs" />
     <Compile Include="Types\OutputState.cs" />
     <Compile Include="Types\SceneItem.cs" />
     <Compile Include="Types\SceneItemBoundsInfo.cs" />
@@ -78,11 +82,19 @@
     <Compile Include="Types\SceneItemCropInfo.cs" />
     <Compile Include="Types\SceneItemPointInfo.cs" />
     <Compile Include="Types\SceneItemPositionInfo.cs" />
+    <Compile Include="Types\SceneItemStub.cs" />
     <Compile Include="Types\SceneItemTransform.cs" />
+    <Compile Include="Types\SceneItemTransformInfo.cs" />
+    <Compile Include="Types\SourceScreenshotResponse.cs" />
+    <Compile Include="Types\SourceTypeCapabilities.cs" />
+    <Compile Include="Types\SourceInfo.cs" />
     <Compile Include="Types\SourceSettings.cs" />
+    <Compile Include="Types\SourceType.cs" />
     <Compile Include="Types\StreamingService.cs" />
     <Compile Include="Types\StreamingServiceSettings.cs" />
     <Compile Include="Types\StreamStatus.cs" />
+    <Compile Include="Types\TextGDIPlusFont.cs" />
+    <Compile Include="Types\TextGDIPlusProperties.cs" />
     <Compile Include="Types\TransitionSettings.cs" />
     <Compile Include="Types\VolumeInfo.cs" />
   </ItemGroup>

--- a/obs-websocket-dotnet/obs-websocket-dotnet.csproj
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.csproj
@@ -83,7 +83,7 @@
     <Compile Include="Types\SceneItemPointInfo.cs" />
     <Compile Include="Types\SceneItemPositionInfo.cs" />
     <Compile Include="Types\SceneItemStub.cs" />
-    <Compile Include="Types\SceneItemTransform.cs" />
+    <Compile Include="Types\SceneItemProperties.cs" />
     <Compile Include="Types\SceneItemTransformInfo.cs" />
     <Compile Include="Types\SourceScreenshotResponse.cs" />
     <Compile Include="Types\SourceTypeCapabilities.cs" />


### PR DESCRIPTION
This adds all of the missing Events and Requests since the last release
Three methods were not included SetSceneItemRender, SetTextFreetype2Properties, and GetTextFreetype2Properties
There is a fix for auth when not connected
Moved most objects out of Types.cs into their own files
Because of the use of Jsonconverter, null exceptions on conversion should go away
There were instances where the documentation reflected an int but in practice those overflowed so a ulong was used in its place. Color properties and the some of the statistics were areas where that was done.