### PR TITLE
Fixing SetBrowserSourceProperties() not actually sending a valid request

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -1166,11 +1166,11 @@ namespace OBSWebsocketDotNet
         /// <param name="sceneName">Optional name of a scene where the specified source can be found</param>
         public void SetBrowserSourceProperties(string sourceName, BrowserSourceProperties props, string sceneName = null)
         {
-            //override sourcename in props with the name passed
             props.Source = sourceName;
-            var request = new JObject();
-            var jsonString = JsonConvert.SerializeObject(request);
-            JsonConvert.PopulateObject(jsonString, request);
+            var request = JObject.FromObject(props);
+            if (sceneName != null)
+                request.Add("scene-name", sourceName);
+
             SendRequest("SetBrowserSourceProperties", request);
         }
 


### PR DESCRIPTION
Fixing the following issue: https://github.com/Palakis/obs-websocket-dotnet/issues/22