### PR TITLE
Fixed TakeSourceScreenshot

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -63,7 +63,7 @@ namespace OBSWebsocketDotNet
         public SourceScreenshotResponse TakeSourceScreenshot(string sourceName, string embedPictureFormat = null, string saveToFilePath = null, int width = -1, int height = -1)
         {
             var requestFields = new JObject();
-                requestFields.Add("sourceName", sourceName);
+            requestFields.Add("sourceName", sourceName);
             if (embedPictureFormat != null)
             {
                 requestFields.Add("embedPictureFormat", embedPictureFormat);

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -79,17 +79,7 @@ namespace OBSWebsocketDotNet
         /// <param name="saveToFilePath">Full file path (file extension included) where the captured image is to be saved. Can be in a format different from pictureFormat. Can be a relative path.</param>
         public SourceScreenshotResponse TakeSourceScreenshot(string sourceName, string embedPictureFormat = null, string saveToFilePath = null)
         {
-            return TakeSourceScreenshot(sourceName, embedPictureFormat, saveToFilePath);
-        }
-
-        /// <summary>
-        /// At least embedPictureFormat or saveToFilePath must be specified.
-        /// Clients can specify width and height parameters to receive scaled pictures. Aspect ratio is preserved if only one of these two parameters is specified.
-        /// </summary>
-        /// <param name="sourceName"></param>
-        public SourceScreenshotResponse TakeSourceScreenshot(string sourceName)
-        {
-            return TakeSourceScreenshot(sourceName);
+            return TakeSourceScreenshot(sourceName, embedPictureFormat, saveToFilePath, -1, -1);
         }
 
         /// <summary>

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -56,13 +56,13 @@ namespace OBSWebsocketDotNet
         public SourceScreenshotResponse TakeSourceScreenshot(string sourceName, string embedPictureFormat = null, string saveToFilePath = null, int width = -1, int height = -1)
         {
             var requestFields = new JObject();
-            requestFields.Add("sourceName", sourceName);
+                requestFields.Add("sourceName", sourceName);
             if (embedPictureFormat != null)
-            requestFields.Add("embedPictureFormat", embedPictureFormat);
+                requestFields.Add("embedPictureFormat", embedPictureFormat);
             if (saveToFilePath != null)
                 requestFields.Add("saveToFilePath", saveToFilePath);
             if (width > -1)
-            requestFields.Add("height", width);
+                requestFields.Add("width", width);
             if (height > -1)
                 requestFields.Add("height", height);
 

--- a/obs-websocket-dotnet/Types/SourceScreenshotResponse.cs
+++ b/obs-websocket-dotnet/Types/SourceScreenshotResponse.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
-    /// Respone from <see cref="OBSWebsocket.TakeSourceScreenshot(string)"/>
+    /// Response from <see cref="OBSWebsocket.TakeSourceScreenshot(string, string, string, int, int)"/>
     /// </summary>
     public class SourceScreenshotResponse
     {
@@ -26,7 +26,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Absolute path to the saved image file(if saveToFilePath was specified in the request)
         /// </summary>
-        [JsonProperty(PropertyName = "imgFile")]
+        [JsonProperty(PropertyName = "imageFile")]
         public string ImageFile { internal set; get; }
     }
 


### PR DESCRIPTION
* Removed `TakeSourceScreenshot(string)` overload since an `embedPictureFormat` or `saveToFilePath` must be specified (and it also calls itself, resulting in a stack overflow).
* Fixed `TakeSourceScreenshot(string,string,string)` so that it doesn't call itself.