### PR TITLE
Updated GetBrowserSourceProperties and SetBrowserSourceProperties to …

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -35,6 +35,14 @@ namespace OBSWebsocketDotNet
     /// </summary>
     public partial class OBSWebsocket
     {
+        #region Private Members
+
+        private const string SOURCE_TYPE_JSON_FIELD = "sourceType";
+        private const string SOURCE_TYPE_BROWSER_SOURCE = "browser_source";
+        private const string SOURCE_SETTINGS_PAYLOAD_FIELD = "sourceSettings";
+
+        #endregion
+
         /// <summary>
         /// Get basic OBS video information
         /// </summary>
@@ -1211,11 +1219,17 @@ namespace OBSWebsocketDotNet
         public BrowserSourceProperties GetBrowserSourceProperties(string sourceName, string sceneName = null)
         {
             var request = new JObject();
-            request.Add("source", sourceName);
+            request.Add("sourceName", sourceName);
             if (sceneName != null)
+            {
                 request.Add("scene-name", sourceName);
+            }
+            var response = SendRequest("GetSourceSettings", request);
+            if (response[SOURCE_TYPE_JSON_FIELD].ToString() != SOURCE_TYPE_BROWSER_SOURCE)
+            {
+                throw new Exception($"Invalid source_type. Expected: {SOURCE_TYPE_BROWSER_SOURCE} Received: {response[SOURCE_TYPE_JSON_FIELD]}");
+            }
 
-            var response = SendRequest("GetBrowserSourceProperties", request);
             return new BrowserSourceProperties(response);
         }
 
@@ -1230,9 +1244,11 @@ namespace OBSWebsocketDotNet
             props.Source = sourceName;
             var request = JObject.FromObject(props);
             if (sceneName != null)
+            {
                 request.Add("scene-name", sourceName);
+            }
 
-            SendRequest("SetBrowserSourceProperties", request);
+            SetSourceSettings(sourceName, request, SOURCE_TYPE_BROWSER_SOURCE);
         }
 
         /// <summary>
@@ -1258,7 +1274,9 @@ namespace OBSWebsocketDotNet
             var request = new JObject();
             request.Add("sourceName", sourceName);
             if (sourceType != null)
+            {
                 request.Add("sourceType", sourceType);
+            }
 
             JObject result = SendRequest("GetSourceSettings", request);
             SourceSettings settings = new SourceSettings(result);
@@ -1278,7 +1296,9 @@ namespace OBSWebsocketDotNet
             request.Add("sourceName", sourceName);
             request.Add("sourceSettings", settings);
             if (sourceType != null)
+            {
                 request.Add("sourceType", sourceType);
+            }
 
             SendRequest("SetSourceSettings", request);
         }

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -39,7 +39,6 @@ namespace OBSWebsocketDotNet
 
         private const string SOURCE_TYPE_JSON_FIELD = "sourceType";
         private const string SOURCE_TYPE_BROWSER_SOURCE = "browser_source";
-        private const string SOURCE_SETTINGS_PAYLOAD_FIELD = "sourceSettings";
 
         #endregion
 
@@ -1321,7 +1320,6 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Sets settings of a media source
         /// </summary>
-        /// <param name="sourceName"></param>
         /// <param name="sourceSettings"></param>
         public void SetMediaSourceSettings(MediaSourceSettings sourceSettings)
         {

--- a/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
+++ b/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
@@ -11,7 +11,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Source name for the browser properties
         /// </summary>
-        [JsonProperty(PropertyName = "source")]
+        [JsonProperty(PropertyName = "sourceName")]
         public string Source;
 
         /// <summary>
@@ -86,7 +86,8 @@ namespace OBSWebsocketDotNet.Types
         /// <param name="props"></param>
         public BrowserSourceProperties(JObject props)
         {
-            JsonConvert.PopulateObject(props.ToString(), this);
+            JsonConvert.PopulateObject(props["sourceSettings"].ToString(), this);
+            Source = props["sourceName"].ToString();
         }
     }
 }


### PR DESCRIPTION
…not use deprecated API

- GetBrowserSourceProperties now calls GetSourceSettings and converts the data into a BrowserSourceProperties
- SetBrowserSourceProperties uses SetSourceSettings to save the changes