### PR TITLE
Fixed bug in SetStreamingSettings

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -1266,11 +1266,11 @@ namespace OBSWebsocketDotNet
         /// <param name="save">Save to disk</param>
         public void SetStreamingSettings(StreamingService service, bool save)
         {
-            var jsonSettings = JsonConvert.SerializeObject(service.Settings);
+            var jtokenSettings = JToken.FromObject(service.Settings);
 
             var requestFields = new JObject();
             requestFields.Add("type", service.Type);
-            requestFields.Add("settings", jsonSettings);
+            requestFields.Add("settings", jtokenSettings);
             requestFields.Add("save", save);
             SendRequest("SetStreamSettings", requestFields);
         }


### PR DESCRIPTION
The JSON was invalid when sending a request to update the stream settings. It was creating a double string which failed to be parsed in the request.