### PR TITLE
add GetRecordingStatus

### DIFF
--- a/obs-websocket-dotnet-tests/UnitTest_Types.cs
+++ b/obs-websocket-dotnet-tests/UnitTest_Types.cs
@@ -145,16 +145,39 @@ namespace OBSWebsocketDotNet.Tests
         }
 
         [TestMethod]
-        public void OBSOutputStatus_BuildFromJSON()
+        public void OBSStreamingStatus_BuildFromJSON()
         {
+            string streamingTimecode = "TestStr";
+
             var data = new JObject();
             data.Add("streaming", true);
             data.Add("recording", true);
+            data.Add("stream-timecode", streamingTimecode);
 
-            var outputState = new OutputStatus(data);
+            var streamingStatus = new StreamingStatus(data);
 
-            Assert.IsTrue(outputState.IsStreaming);
-            Assert.IsTrue(outputState.IsRecording);
+            Assert.IsTrue(streamingStatus.IsStreaming);
+            Assert.IsTrue(streamingStatus.IsRecording);
+            Assert.AreEqual(streamingStatus.StreamingTimecode, streamingTimecode);
+            Assert.IsNull(streamingStatus.RecordingTimecode);
+        }
+
+        [TestMethod]
+        public void OBSRecordingStatus_BuildFromJSON()
+        {
+            string recordingTimecode = "TestStr";
+
+            var data = new JObject();
+            data.Add("isRecording", true);
+            data.Add("isRecordingPaused", true);
+            data.Add("recordTimecode", recordingTimecode);
+
+            var recordingStatus = new RecordingStatus(data);
+
+            Assert.IsTrue(recordingStatus.IsRecording);
+            Assert.IsTrue(recordingStatus.IsRecordingPaused);
+            Assert.AreEqual(recordingStatus.RecordingTimecode, recordingTimecode);
+            Assert.IsNull(recordingStatus.RecordingFilename);
         }
 
         [TestMethod]

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -499,12 +499,23 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Get the current status of the streaming and recording outputs
         /// </summary>
-        /// <returns>An <see cref="OutputStatus"/> object describing the current outputs states</returns>
-        public OutputStatus GetStreamingStatus()
+        /// <returns>An <see cref="StreamingStatus"/> object describing the current outputs states</returns>
+        public StreamingStatus GetStreamingStatus()
         {
             JObject response = SendRequest("GetStreamingStatus");
-            var outputStatus = new OutputStatus(response);
-            return outputStatus;
+            var streamingStatus = new StreamingStatus(response);
+            return streamingStatus;
+        }
+
+        /// <summary>
+        /// Get the current status of the recording
+        /// </summary>
+        /// <returns>An <see cref="RecordingStatus"/> object describing the current outputs states</returns>
+        public RecordingStatus GetRecordingStatus()
+        {
+            JObject response = SendRequest("GetRecordingStatus");
+            var recordingStatus = new RecordingStatus(response);
+            return recordingStatus;
         }
 
         /// <summary>

--- a/obs-websocket-dotnet/Types/RecordingStatus.cs
+++ b/obs-websocket-dotnet/Types/RecordingStatus.cs
@@ -1,0 +1,48 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OBSWebsocketDotNet
+{
+    /// <summary>
+    /// Status of streaming output and recording output
+    /// </summary>
+    public class RecordingStatus
+    {
+        /// <summary>
+        /// Current recording status
+        /// </summary>
+        [JsonProperty(PropertyName = "isRecording")]
+        public readonly bool IsRecording;
+
+        /// <summary>
+        /// Whether the recording is paused or not.
+        /// </summary>
+        [JsonProperty(PropertyName = "isRecordingPaused")]
+        public readonly bool IsRecordingPaused;
+
+        /// <summary>
+        /// Time elapsed since recording started (only present if currently recording).
+        /// </summary>
+        [JsonProperty(PropertyName = "recordTimecode")]
+        public readonly string RecordingTimecode;
+
+        /// <summary>
+        /// Absolute path to the recording file (only present if currently recording).
+        /// </summary>
+        [JsonProperty(PropertyName = "recordingFilename")]
+        public readonly string RecordingFilename;
+
+        /// <summary>
+        /// Builds the object from the JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public RecordingStatus(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/StreamingStatus.cs
+++ b/obs-websocket-dotnet/Types/StreamingStatus.cs
@@ -21,6 +21,7 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// True if recording is started and running, false otherwise
         /// </summary>
+        [ObsoleteAttribute("Use GetRecordingStatus instead. recording will be obsoleted in websockets v5.0. See https://github.com/Palakis/obs-websocket/pull/549")]
         [JsonProperty(PropertyName = "recording")]
         public readonly bool IsRecording;
 
@@ -33,6 +34,7 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Time elapsed since recording started (only present if currently recording)
         /// </summary>
+        [ObsoleteAttribute("Use GetRecordingStatus instead. rec-timecode will be obsoleted in websockets v5.0. See https://github.com/Palakis/obs-websocket/pull/549")]
         [JsonProperty(PropertyName = "rec-timecode")]
         public readonly string RecordingTimecode;
 

--- a/obs-websocket-dotnet/Types/StreamingStatus.cs
+++ b/obs-websocket-dotnet/Types/StreamingStatus.cs
@@ -10,13 +10,12 @@ namespace OBSWebsocketDotNet
     /// <summary>
     /// Status of streaming output and recording output
     /// </summary>
-    public class OutputStatus
+    public class StreamingStatus
     {
         /// <summary>
         /// True if streaming is started and running, false otherwise
         /// </summary>
         [JsonProperty(PropertyName = "streaming")]
-
         public readonly bool IsStreaming;
 
         /// <summary>
@@ -26,10 +25,22 @@ namespace OBSWebsocketDotNet
         public readonly bool IsRecording;
 
         /// <summary>
+        /// Time elapsed since recording started (only present if currently recording)
+        /// </summary>
+        [JsonProperty(PropertyName = "stream-timecode")]
+        public readonly string StreamingTimecode;
+
+        /// <summary>
+        /// Time elapsed since recording started (only present if currently recording)
+        /// </summary>
+        [JsonProperty(PropertyName = "rec-timecode")]
+        public readonly string RecordingTimecode;
+
+        /// <summary>
         /// Builds the object from the JSON response body
         /// </summary>
         /// <param name="data">JSON response body as a <see cref="JObject"/></param>
-        public OutputStatus(JObject data)
+        public StreamingStatus(JObject data)
         {
             JsonConvert.PopulateObject(data.ToString(), this);
         }


### PR DESCRIPTION
Adds GetRecordingStatus for websockets v4.9 (see [here](https://github.com/Palakis/obs-websocket/pull/549)).

OutputStatus is renamed to keep it in line with the other types. This might break compatibility though.
Another possibility would be to just add GetRecordingStatus and leave OutputStatus until websockets v5.0, where the recording and rec-timecode fields will be removed and OutputStatus will have to be rewritten anyway.