### PR TITLE
Prevent an easy error in Connect()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.idea
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -320,8 +320,8 @@ namespace OBSWebsocketDotNet
         /// <param name="password">Server password</param>
         public void Connect(string url, string password)
         {
-            if (url.ToLower().StartsWith("ws://") == false)
-                url = "ws://" + url;
+            if (!url.ToLower().StartsWith("ws://"))
+                throw new ErrorResponseException(@"Invalid server url, must start with 'ws://'");
             
             if (WSConnection != null && WSConnection.IsAlive)
                 Disconnect();

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -320,6 +320,9 @@ namespace OBSWebsocketDotNet
         /// <param name="password">Server password</param>
         public void Connect(string url, string password)
         {
+            if (url.ToLower().StartsWith("ws://") == false)
+                url = "ws://" + url;
+            
             if (WSConnection != null && WSConnection.IsAlive)
                 Disconnect();
 


### PR DESCRIPTION
Basically if the user of the library forgets to include `ws://` in the url, the library will return a very useless error, specifically

```
Unhandled exception. System.ArgumentException: A relative URI. (Parameter 'url')
```
Which does not help. This prevents that error from ever happening by correcting a forgotten web socket protocol specifier.

It also adds *.idea to the .gitignore, because Rider creates that.