### PR TITLE
[obs-websocket - Enhancement] - Add volumeDb to the SourceVolumeChanged event

### DIFF
--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -217,7 +217,7 @@ namespace OBSWebsocketDotNet
     /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
     /// <param name="sourceName">Name of source</param>
     /// <param name="volume">Current volume level of source</param>
-    public delegate void SourceVolumeChangedCallback(OBSWebsocket sender, string sourceName, float volume);
+    public delegate void SourceVolumeChangedCallback(OBSWebsocket sender, string sourceName, float volume, float volumeDb);
 
     /// <summary>
     /// Callback by <see cref="OBSWebsocket.SourceFilterRemoved"/>

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -215,9 +215,8 @@ namespace OBSWebsocketDotNet
     /// Callback by <see cref="OBSWebsocket.SourceVolumeChanged"/>
     /// </summary>
     /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sourceName">Name of source</param>
-    /// <param name="volume">Current volume level of source</param>
-    public delegate void SourceVolumeChangedCallback(OBSWebsocket sender, string sourceName, float volume, float volumeDb);
+    /// <param name="volume">Current volume levels of source</param>
+    public delegate void SourceVolumeChangedCallback(OBSWebsocket sender, SourceVolume volume);
 
     /// <summary>
     /// Callback by <see cref="OBSWebsocket.SourceFilterRemoved"/>

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -744,7 +744,7 @@ namespace OBSWebsocketDotNet
                     SourceAudioActivated?.Invoke(this, (string)body["sourceName"]);
                     break;
                 case "SourceVolumeChanged":
-                    SourceVolumeChanged?.Invoke(this, (string)body["sourceName"], (float)body["volume"], (float)body["volumeDb"]);
+                    SourceVolumeChanged?.Invoke(this, new SourceVolume(body));
                     break;
                 case "SourceFilterAdded":
                     SourceFilterAdded?.Invoke(this, (string)body["sourceName"], (string)body["filterName"], (string)body["filterType"], (JObject)body["filterSettings"]);

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -744,7 +744,7 @@ namespace OBSWebsocketDotNet
                     SourceAudioActivated?.Invoke(this, (string)body["sourceName"]);
                     break;
                 case "SourceVolumeChanged":
-                    SourceVolumeChanged?.Invoke(this, (string)body["sourceName"], (float)body["volume"]);
+                    SourceVolumeChanged?.Invoke(this, (string)body["sourceName"], (float)body["volume"], (float)body["volumeDb"]);
                     break;
                 case "SourceFilterAdded":
                     SourceFilterAdded?.Invoke(this, (string)body["sourceName"], (string)body["filterName"], (string)body["filterType"], (JObject)body["filterSettings"]);

--- a/obs-websocket-dotnet/Types/SourceVolume.cs
+++ b/obs-websocket-dotnet/Types/SourceVolume.cs
@@ -1,4 +1,7 @@
-﻿namespace OBSWebsocketDotNet.Types
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
     /// Source volume values
@@ -6,12 +9,33 @@
     public class SourceVolume
     {
         /// <summary>
+        /// Name of the source
+        /// </summary>
+        [JsonProperty(PropertyName = "sourceName")]
+        public string SourceName { set; get; }
+        /// <summary>
         /// The source volume in percent
         /// </summary>
+        [JsonProperty(PropertyName = "volume")]
         public float Volume { get; set; }
         /// <summary>
         /// The source volume in decibels
         /// </summary>
+        [JsonProperty(PropertyName = "volumeDb")]
         public float VolumeDb { get; set; }
+
+        /// <summary>
+        /// Builds the object from the JSON response body
+        /// </summary>
+        /// <param name="data">JSON response body as a <see cref="JObject"/></param>
+        public SourceVolume(JObject data)
+        {
+            JsonConvert.PopulateObject(data.ToString(), this);
+        }
+
+        /// <summary>
+        /// Empty constructor for jsonconvert
+        /// </summary>
+        public SourceVolume() { }
     }
 }

--- a/obs-websocket-dotnet/Types/SourceVolume.cs
+++ b/obs-websocket-dotnet/Types/SourceVolume.cs
@@ -1,0 +1,17 @@
+﻿namespace OBSWebsocketDotNet.Types
+{
+    /// <summary>
+    /// Source volume values
+    /// </summary>
+    public class SourceVolume
+    {
+        /// <summary>
+        /// The source volume in percent
+        /// </summary>
+        public float Volume { get; set; }
+        /// <summary>
+        /// The source volume in decibels
+        /// </summary>
+        public float VolumeDb { get; set; }
+    }
+}


### PR DESCRIPTION
Adds volumeDb to the SourceVolumeChanged event.

https://github.com/Palakis/obs-websocket/releases/tag/4.9.1
https://github.com/Palakis/obs-websocket/blob/4.9.1/docs/generated/protocol.md#sourcevolumechanged

This will probably break things for anyone using the event from previous versions.

Input welcome.

