### PR TITLE
Fixes the websocket deadlock possibilty in events

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -448,7 +448,7 @@ namespace OBSWebsocketDotNet
             {
                 // Handle an event
                 string eventType = body["update-type"].ToString();
-                ProcessEventType(eventType, body);
+                Task.Run(() => { ProcessEventType(eventType, body); });
             }
         }
 


### PR DESCRIPTION
Events are now processed async, so that the websocket event can return
immediately (as it doesn't expect a return value anyway).
Fixes #73