### PR TITLE
Fix width and height being swapped on TextGDIPlusProperties

### DIFF
--- a/obs-websocket-dotnet/Types/TextGDIPlusProperties.cs
+++ b/obs-websocket-dotnet/Types/TextGDIPlusProperties.cs
@@ -58,13 +58,13 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Extents cx.
         /// </summary>
-        [JsonProperty(PropertyName = "extents_cx")]
+        [JsonProperty(PropertyName = "extents_cy")]
         public int Height { set; get; }
 
         /// <summary>
         /// Extents cy.
         /// </summary>
-        [JsonProperty(PropertyName = "extents_cy")]
+        [JsonProperty(PropertyName = "extents_cx")]
         public int Width { set; get; }
 
         /// <summary>


### PR DESCRIPTION
I noticed this when stuff broke :)

I have confirmed this is the right way, however, this will break backwards compatibility of anyone who has used the library so far.