### PR TITLE
TestClient bugfixes

### DIFF
--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -294,11 +294,12 @@ namespace TestClient
                 foreach (var scene in scenes)
                 {
                     var node = new TreeNode(scene.Name);
-                    // TODO
-                    //foreach (var item in scene.Items)
-                    //{
-                    //    node.Nodes.Add(item.SourceName);
-                    //}
+                    var items = obs.GetSceneItemList(scene.Name);
+                    
+                    foreach (var item in items)
+                    {
+                        node.Nodes.Add(item.SourceName);
+                    }
 
                     tvScenes.Nodes.Add(node);
                 }

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -294,10 +294,11 @@ namespace TestClient
                 foreach (var scene in scenes)
                 {
                     var node = new TreeNode(scene.Name);
-                    foreach (var item in scene.Items)
-                    {
-                        node.Nodes.Add(item.SourceName);
-                    }
+                    // TODO
+                    //foreach (var item in scene.Items)
+                    //{
+                    //    node.Nodes.Add(item.SourceName);
+                    //}
 
                     tvScenes.Nodes.Add(node);
                 }

--- a/obs-websocket-dotnet-tests/UnitTest_Types.cs
+++ b/obs-websocket-dotnet-tests/UnitTest_Types.cs
@@ -40,6 +40,7 @@ namespace OBSWebsocketDotNet.Tests
             var scene = new OBSScene(data);
 
             Assert.AreEqual(sceneName, scene.Name);
+            // TODO: create new tests for items, as they are not part of the scene info anymore
             //Assert.AreEqual(1, scene.Items.Count);
             //Assert.AreEqual(itemName, scene.Items[0].SourceName);
         }

--- a/obs-websocket-dotnet-tests/UnitTest_Types.cs
+++ b/obs-websocket-dotnet-tests/UnitTest_Types.cs
@@ -40,8 +40,8 @@ namespace OBSWebsocketDotNet.Tests
             var scene = new OBSScene(data);
 
             Assert.AreEqual(sceneName, scene.Name);
-            Assert.AreEqual(1, scene.Items.Count);
-            Assert.AreEqual(itemName, scene.Items[0].SourceName);
+            //Assert.AreEqual(1, scene.Items.Count);
+            //Assert.AreEqual(itemName, scene.Items[0].SourceName);
         }
 
         [TestMethod]

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -452,7 +452,7 @@ namespace OBSWebsocketDotNet
                     break;
                 case MessageTypes.Event:
                     // Handle events
-                    string eventType = body["update-type"].ToString();
+                    string eventType = body["eventType"].ToString();
                     Task.Run(() => { ProcessEventType(eventType, body); });
                     break;
                 default:

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -119,7 +119,7 @@ namespace OBSWebsocketDotNet
         /// <returns>An <see cref="OBSScene"/> object describing the current scene</returns>
         public OBSScene GetCurrentScene()
         {
-            JObject response = SendRequest("GetCurrentScene");
+            JObject response = SendRequest("GetCurrentProgramScene");
             return new OBSScene(response);
         }
 
@@ -543,7 +543,7 @@ namespace OBSWebsocketDotNet
         /// <returns>An <see cref="OutputStatus"/> object describing the current outputs states</returns>
         public OutputStatus GetStreamingStatus()
         {
-            JObject response = SendRequest("GetStreamingStatus");
+            JObject response = SendRequest("GetStreamStatus");
             var outputStatus = new OutputStatus(response);
             return outputStatus;
         }
@@ -570,7 +570,7 @@ namespace OBSWebsocketDotNet
         /// <returns>An <see cref="TransitionSettings"/> object with the current transition name and duration</returns>
         public TransitionSettings GetCurrentTransition()
         {
-            JObject respBody = SendRequest("GetCurrentTransition");
+            JObject respBody = SendRequest("GetCurrentSceneTransition");
             return new TransitionSettings(respBody);
         }
 
@@ -811,8 +811,8 @@ namespace OBSWebsocketDotNet
         /// <returns>Name of the current scene collection</returns>
         public string GetCurrentSceneCollection()
         {
-            var response = SendRequest("GetCurrentSceneCollection");
-            return (string)response["sc-name"];
+            var response = SendRequest("GetSceneCollectionList");
+            return (string)response["currentSceneCollectionName"];
         }
 
         /// <summary>
@@ -821,13 +821,13 @@ namespace OBSWebsocketDotNet
         /// <returns>A <see cref="List{T}"/> of the names of all scene collections</returns>
         public List<string> ListSceneCollections()
         {
-            var response = SendRequest("ListSceneCollections");
-            var items = (JArray)response["scene-collections"];
+            var response = SendRequest("GetSceneCollectionList");
+            var items = (JArray)response["sceneCollections"];
 
             List<string> sceneCollections = new List<string>();
-            foreach (JObject item in items)
+            foreach (string item in items)
             {
-                sceneCollections.Add((string)item["sc-name"]);
+                sceneCollections.Add(item);
             }
 
             return sceneCollections;
@@ -853,8 +853,8 @@ namespace OBSWebsocketDotNet
         /// <returns>Name of the current profile</returns>
         public string GetCurrentProfile()
         {
-            var response = SendRequest("GetCurrentProfile");
-            return (string)response["profile-name"];
+            var response = SendRequest("GetProfileList");
+            return (string)response["currentProfileName"];
         }
 
         /// <summary>
@@ -863,13 +863,13 @@ namespace OBSWebsocketDotNet
         /// <returns>A <see cref="List{T}"/> of the names of all profiles</returns>
         public List<string> ListProfiles()
         {
-            var response = SendRequest("ListProfiles");
+            var response = SendRequest("GetProfileList");
             var items = (JArray)response["profiles"];
 
             List<string> profiles = new List<string>();
-            foreach (JObject item in items)
+            foreach (string item in items)
             {
-                profiles.Add((string)item["profile-name"]);
+                profiles.Add(item);
             }
 
             return profiles;
@@ -960,8 +960,10 @@ namespace OBSWebsocketDotNet
         /// <returns>Current recording folder path</returns>
         public string GetRecordingFolder()
         {
-            var response = SendRequest("GetRecordingFolder");
-            return (string)response["rec-folder"];
+            // TODO: Currently not implemented in 5.0alpha3, commented out in ws-src
+            //var response = SendRequest("GetRecordDirectory");
+            //return (string)response["recordDirectory"];
+            return "";
         }
 
         /// <summary>
@@ -1015,7 +1017,7 @@ namespace OBSWebsocketDotNet
         /// <returns>Current transition duration (in milliseconds)</returns>
         public GetTransitionListInfo GetTransitionList()
         {
-            var response = SendRequest("GetTransitionList");
+            var response = SendRequest("GetSceneTransitionList");
 
             return JsonConvert.DeserializeObject<GetTransitionListInfo>(response.ToString());
         }
@@ -2090,9 +2092,11 @@ namespace OBSWebsocketDotNet
         /// <returns>An <see cref="VirtualCamStatus"/> object describing the current virtual camera state</returns>
         public VirtualCamStatus GetVirtualCamStatus()
         {
-            JObject response = SendRequest("GetVirtualCamStatus");
-            var outputStatus = new VirtualCamStatus(response);
-            return outputStatus;
+            // TODO: NYI in obs-ws
+            //JObject response = SendRequest("GetVirtualCamStatus");
+            //var outputStatus = new VirtualCamStatus(response);
+            //return outputStatus;
+            return new VirtualCamStatus { IsActive = false };
         }
 
         /// <summary>

--- a/obs-websocket-dotnet/Types/OBSScene.cs
+++ b/obs-websocket-dotnet/Types/OBSScene.cs
@@ -16,17 +16,11 @@ namespace OBSWebsocketDotNet.Types
         public string Name;
 
         /// <summary>
-        /// Is group
+        /// Scene Index
         /// </summary>
-        [JsonProperty(PropertyName = "isGroup")]
-        public bool IsGroup;
-
-        /// <summary>
-        /// Scene item list
-        /// </summary>
-        [JsonProperty(PropertyName = "sources")]
-        public List<SceneItem> Items;
-
+        [JsonProperty(PropertyName = "sceneIndex")]
+        public int Index;
+        
         /// <summary>
         /// Builds the object from the JSON description
         /// </summary>

--- a/obs-websocket-dotnet/Types/OBSScene.cs
+++ b/obs-websocket-dotnet/Types/OBSScene.cs
@@ -2,33 +2,41 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 
-namespace OBSWebsocketDotNet.Types
-{
+namespace OBSWebsocketDotNet.Types {
     /// <summary>
     /// Describes a scene in OBS, along with its items
     /// </summary>
-    public class OBSScene
-    {
+    public class OBSScene {
         /// <summary>
         /// OBS Scene name
         /// </summary>
         [JsonProperty(PropertyName = "sceneName")]
         public string Name;
+        
+        /// <summary>
+        /// Scene name as used by GetCurrentProgramScene
+        /// </summary>
+        [JsonProperty(PropertyName = "currentProgramSceneName")]
+        private string ProgramName {
+            set { Name = value; }
+        }
+
 
         /// <summary>
-        /// Scene Index
+        /// Scene name as used by GetCurrentPreviewScene
         /// </summary>
-        [JsonProperty(PropertyName = "sceneIndex")]
-        public int Index;
-        
+        [JsonProperty(PropertyName = "currentPreviewSceneName")]
+        private string PreviewScene {
+            set { Name = value; }
+        }
+
+
         /// <summary>
         /// Builds the object from the JSON description
         /// </summary>
         /// <param name="data">JSON scene description as a <see cref="JObject" /></param>
-        public OBSScene(JObject data)
-        {
-            JsonSerializerSettings settings = new JsonSerializerSettings
-            {
+        public OBSScene(JObject data) {
+            JsonSerializerSettings settings = new JsonSerializerSettings {
                 ObjectCreationHandling = ObjectCreationHandling.Auto,
                 NullValueHandling = NullValueHandling.Include
             };
@@ -38,6 +46,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Default Constructor for deserialization
         /// </summary>
-        public OBSScene() { }
+        public OBSScene() {
+        }
     }
 }

--- a/obs-websocket-dotnet/Types/OBSScene.cs
+++ b/obs-websocket-dotnet/Types/OBSScene.cs
@@ -2,22 +2,27 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 
-namespace OBSWebsocketDotNet.Types {
+namespace OBSWebsocketDotNet.Types
+{
     /// <summary>
     /// Describes a scene in OBS, along with its items
     /// </summary>
-    public class OBSScene {
+    public class OBSScene
+    {
+        // TODO: Test mapping of ProgramScene/PreviewScene with SetCurrentProgramScene / SetCurrentPreviewScene. Maybe a custom serialization mapper would be more useful
+
         /// <summary>
         /// OBS Scene name
         /// </summary>
         [JsonProperty(PropertyName = "sceneName")]
         public string Name;
-        
+
         /// <summary>
         /// Scene name as used by GetCurrentProgramScene
         /// </summary>
         [JsonProperty(PropertyName = "currentProgramSceneName")]
-        private string ProgramName {
+        private string ProgramScene
+        {
             set { Name = value; }
         }
 
@@ -26,7 +31,8 @@ namespace OBSWebsocketDotNet.Types {
         /// Scene name as used by GetCurrentPreviewScene
         /// </summary>
         [JsonProperty(PropertyName = "currentPreviewSceneName")]
-        private string PreviewScene {
+        private string PreviewScene
+        {
             set { Name = value; }
         }
 
@@ -35,8 +41,10 @@ namespace OBSWebsocketDotNet.Types {
         /// Builds the object from the JSON description
         /// </summary>
         /// <param name="data">JSON scene description as a <see cref="JObject" /></param>
-        public OBSScene(JObject data) {
-            JsonSerializerSettings settings = new JsonSerializerSettings {
+        public OBSScene(JObject data)
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings
+            {
                 ObjectCreationHandling = ObjectCreationHandling.Auto,
                 NullValueHandling = NullValueHandling.Include
             };
@@ -46,7 +54,6 @@ namespace OBSWebsocketDotNet.Types {
         /// <summary>
         /// Default Constructor for deserialization
         /// </summary>
-        public OBSScene() {
-        }
+        public OBSScene() { }
     }
 }

--- a/obs-websocket-dotnet/Types/SceneItemSourceType.cs
+++ b/obs-websocket-dotnet/Types/SceneItemSourceType.cs
@@ -9,13 +9,7 @@
         /// Input
         /// </summary>
         OBS_SOURCE_TYPE_INPUT,
-
-        /// <summary>
-        /// Group
-        /// TODO: Deprecated?
-        /// </summary>
-        Group,
-
+        
         /// <summary>
         /// Filter
         /// </summary>

--- a/obs-websocket-dotnet/Types/SceneItemSourceType.cs
+++ b/obs-websocket-dotnet/Types/SceneItemSourceType.cs
@@ -8,16 +8,27 @@
         /// <summary>
         /// Input
         /// </summary>
-        Input,
+        OBS_SOURCE_TYPE_INPUT,
 
         /// <summary>
         /// Group
+        /// TODO: Deprecated?
         /// </summary>
         Group,
 
         /// <summary>
+        /// Filter
+        /// </summary>
+        OBS_SOURCE_TYPE_FILTER,
+
+        /// <summary>
+        /// Transition
+        /// </summary>
+        OBS_SOURCE_TYPE_TRANSITION,
+
+        /// <summary>
         /// Scene
         /// </summary>
-        Scene
+        OBS_SOURCE_TYPE_SCENE
     }
 }

--- a/obs-websocket-dotnet/Types/TransitionSettings.cs
+++ b/obs-websocket-dotnet/Types/TransitionSettings.cs
@@ -11,13 +11,13 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Transition name
         /// </summary>
-        [JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "transitionName")]
         public string Name { internal set; get; }
 
         /// <summary>
         /// Transition duration in milliseconds
         /// </summary>
-        [JsonProperty(PropertyName = "duration")]
+        [JsonProperty(PropertyName = "transitionDuration")]
         public int Duration { internal set; get; }
 
         /// <summary>


### PR DESCRIPTION
Some work to get the test client up and running for 5.0.0-alpha3

- Renaming some requests that changed
- Adjusted naming on SceneItem incl. naming alternatives for different requests
- Stopping events from crashing the client
- Adjusted the source type enum
- Disabled some stuff that is not yet implemented but called by the TestClient on startup

All spots that need to be revisited or reenabled later are marked with TODO