### PR TITLE
Fix StreamingServiceSettings.UseAuth JSON property name

### DIFF
--- a/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
+++ b/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
@@ -22,7 +22,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// Indicates whether authentication should be used when connecting to the streaming server
         /// </summary>
-        [JsonProperty(PropertyName = "use-auth")]
+        [JsonProperty(PropertyName = "use_auth")]
         public bool UseAuth { set; get; }
 
         /// <summary>


### PR DESCRIPTION
The JsonProperty attribute had the incorrect name for this setting causing OBS to not use credentials when UseAuth is true.

I checked the OBS source and it looks like use_auth has been the setting name since the feature was added in 2015 so there should be no issue with OBS backwards compatibility.