### PR TITLE
Throw execption when connection to websocket server fails.

### DIFF
--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -382,7 +382,9 @@ namespace OBSWebsocketDotNet
             WSConnection.Connect();
 
             if (!WSConnection.IsAlive)
-                return;
+            {
+                throw new ErrorResponseException($"Could not connect to '{url}'.");
+            }
 
             OBSAuthInfo authInfo = GetAuthInfo();
 


### PR DESCRIPTION
Instead of just returning from the Connect method we should inform the caller that the connection did not work by throwing an exception. Thus the caller is able to react.