### PR TITLE
Implemented high-volume events, dynamic reidentify, new event protocol

### DIFF
--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -2,11 +2,10 @@
 using Newtonsoft.Json.Linq;
 using OBSWebsocketDotNet.Communication;
 using OBSWebsocketDotNet.Types;
+using OBSWebsocketDotNet.Types.Events;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using OBSWebsocketDotNet.Types.Events;
-using System.Data.Common;
 using System.Net.WebSockets;
 using Websocket.Client;
 

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -267,8 +267,6 @@ namespace OBSWebsocketDotNet
         /// </summary>
         public event EventHandler<InputAudioMonitorTypeChangedEventArgs> InputAudioMonitorTypeChanged;
 
-
-        private event EventHandler<InputVolumeMetersEventArgs> inputVolumeMeters;
         /// <summary>
         /// A high-volume event providing volume levels of all active inputs every 50 milliseconds.
         /// </summary>
@@ -292,6 +290,7 @@ namespace OBSWebsocketDotNet
                 }
             }
         }
+        private event EventHandler<InputVolumeMetersEventArgs> inputVolumeMeters;
 
         /// <summary>
         /// The replay buffer has been saved.

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -287,7 +287,8 @@ namespace OBSWebsocketDotNet
         {
             var requestFields = new JObject
             {
-                { "rpcVersion", SUPPORTED_RPC_VERSION }
+                { "rpcVersion", SUPPORTED_RPC_VERSION },
+                { "eventSubscriptions", (uint)registeredEvents }
             };
 
             if (authInfo != null)
@@ -301,7 +302,7 @@ namespace OBSWebsocketDotNet
 
             SendRequest(MessageTypes.Identify, null, requestFields, false);
         }
-
+        
         /// <summary>
         /// Encode a Base64-encoded SHA-256 hash
         /// </summary>

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -302,7 +302,7 @@ namespace OBSWebsocketDotNet
 
             SendRequest(MessageTypes.Identify, null, requestFields, false);
         }
-        
+
         /// <summary>
         /// Encode a Base64-encoded SHA-256 hash
         /// </summary>

--- a/obs-websocket-dotnet/Types/EventSubscription.cs
+++ b/obs-websocket-dotnet/Types/EventSubscription.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    [Flags]
+    internal enum EventSubscription
+    {
+        None = 0,
+        General = (1 << 0),
+        Config = (1 << 1),
+        Scenes = (1 << 2),
+        Inputs = (1 << 3),
+        Transitions = (1 << 4),
+        Filters = (1 << 5),
+        Outputs = (1 << 6),
+        SceneItems = (1 << 7),
+        MediaInputs = (1 << 8),
+        Vendors = (1 << 9),
+        Ui = (1 << 10),
+        All = (General | Config | Scenes | Inputs | Transitions | Filters | Outputs | SceneItems | MediaInputs | Vendors | Ui),
+
+        // High volume event need separate subscription
+
+        InputVolumeMeters = (1 << 16),
+        InputActiveStateChanged = (1 << 17),
+        InputShowStateChanged = (1 << 18),
+        SceneItemTransformChanged = (1 << 19)
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputVolumeMetersEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputVolumeMetersEventArgs.cs
@@ -12,13 +12,13 @@ namespace OBSWebsocketDotNet.Types.Events
         /// <summary>
         /// Array of active inputs with their associated volume levels
         /// </summary>
-        public List<JObject> inputs { get; }
+        public List<InputVolumeMeter> inputs { get; }
 
         /// <summary>
         /// Default Constructor
         /// </summary>
         /// <param name="inputs">Collection inputs as JObjects</param>
-        public InputVolumeMetersEventArgs(List<JObject> inputs)
+        public InputVolumeMetersEventArgs(List<InputVolumeMeter> inputs)
         {
             this.inputs = inputs;
         }

--- a/obs-websocket-dotnet/Types/InputVolumeMeter.cs
+++ b/obs-websocket-dotnet/Types/InputVolumeMeter.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace OBSWebsocketDotNet.Types
+{
+    public class InputVolumeMeter
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        [JsonProperty(PropertyName = "inputName")]
+        public string InputName { set; get; }
+
+        // Convert json Array of 3 scalars, into a struct
+        private class ChannelLevelConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(ChannelLevel);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                if (reader.TokenType != JsonToken.StartArray)
+                    throw new ProtocolViolationException("Expected InputVolumeMeter/inputLevelsMul to be an array");
+
+                JToken token = JToken.Load(reader);
+                var items = token.ToObject<float[]>();
+
+                if (items.Length != 3)
+                    throw new ProtocolViolationException($"Expected InputVolumeMeter/inputLevelsMul to be an 3 element array, but instead got {items.Length} element array");
+
+                ChannelLevel contentStruct;
+                contentStruct.PeakRaw = items[0];
+                contentStruct.PeakWithVolume = items[1];
+                contentStruct.magnitudeWithVolume = items[2];
+                return contentStruct;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [JsonConverter(typeof(ChannelLevelConverter))]
+        public struct ChannelLevel
+        {
+            // https://github.com/obsproject/obs-websocket/blob/f4b72b69ce7f9ec6a5fdb1b06971e00d2b091bec/src/utils/Obs_VolumeMeter.cpp#L87
+
+
+            public float magnitudeWithVolume;
+            public float PeakWithVolume;
+            public float PeakRaw;
+        }
+
+        /// <summary>
+        /// Array of channels on this input
+        /// </summary>
+        [JsonProperty(PropertyName = "inputLevelsMul")]
+        public List<ChannelLevel> InputLevels { set; get; }
+
+
+    }
+}


### PR DESCRIPTION
Implemented events for protocol v5 ("update-type" changes to "eventType" and event data is in "eventData" member)
Implemented InputVolumeMeters event as a example of a high-volume event that requires dynamic subscription (via Reidentify) for the event


By the way your discord link in readme isn't working.