### PR TITLE
Feature/event handlers #99

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+.idea/

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -126,14 +126,14 @@ namespace TestClient
             LogMessage($"[ReplayBufferStateChanged] Active: {outputState.IsActive} State: {outputState.StateStr} {outputState.State}");
         }
 
-        private void Obs_RecordStateChanged(OBSWebsocket sender, RecordStateChanged outputState)
+        private void Obs_RecordStateChanged(object sender, RecordStateChangedEventArgs args)
         {
-            LogMessage($"[RecordingStateChanged] Active: {outputState.IsActive} Output: {outputState.OutputPath} State: {outputState.StateStr} {outputState.State}");
+            LogMessage($"[RecordingStateChanged] Active: {args.OutputState.IsActive} Output: {args.OutputState.OutputPath} State: {args.OutputState.StateStr} {args.OutputState.State}");
         }
 
-        private void Obs_StreamStateChanged(OBSWebsocket sender, OutputStateChanged outputState)
+        private void Obs_StreamStateChanged(object sender, StreamStateChangedEventArgs args)
         {
-            LogMessage($"[StreamStateChanged] Active: {outputState.IsActive} State: {outputState.StateStr} {outputState.State}");
+            LogMessage($"[StreamStateChanged] Active: {args.OutputState.IsActive} State: {args.OutputState.StateStr} {args.OutputState.State}");
         }
 
         private void Obs_VirtualcamStateChanged(OBSWebsocket sender, OutputStateChanged outputState)
@@ -142,10 +142,10 @@ namespace TestClient
         }
 
 
-        private void Obs_ProfileListChanged(OBSWebsocket sender, List<string> profiles)
+        private void Obs_ProfileListChanged(object sender, ProfileListChangedEventArgs args)
         {
-            LogMessage($"[ProfileListchanged] Count: {profiles.Count}");
-            foreach (var profile in profiles)
+            LogMessage($"[ProfileListchanged] Count: {args.Profiles.Count}");
+            foreach (var profile in args.Profiles)
             {
                 LogMessage($"\t{profile}");
             }

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -91,19 +91,19 @@ namespace TestClient
             LogMessage($"[InputActiveStateChanged] Name: {inputName} Video Active: {videoActive}");
         }
 
-        private void Obs_InputMuteStateChanged(OBSWebsocket sender, string inputName, bool inputMuted)
+        private void Obs_InputMuteStateChanged(object sender, InputMuteStateChangedEventArgs args)
         {
-            LogMessage($"[InputMuteStateChanged] Name: {inputName} Muted: {inputMuted}");
+            LogMessage($"[InputMuteStateChanged] Name: {args.InputName} Muted: {args.InputMuted}");
         }
 
-        private void Obs_SceneItemTransformChanged(OBSWebsocket sender, string sceneName, string sceneItemId, SceneItemTransformInfo transform)
+        private void Obs_SceneItemTransformChanged(object sender, SceneItemTransformEventArgs args)
         {
-            LogMessage($"[SceneItemTransformChanged] Scene: {sceneName} ItemId: {sceneItemId} Transform: {transform.X},{transform.Y}");
+            LogMessage($"[SceneItemTransformChanged] Scene: {args.SceneName} ItemId: {args.SceneItemId} Transform: {args.Transform.X},{args.Transform.Y}");
         }
 
-        private void Obs_SceneItemSelected(OBSWebsocket sender, string sceneName, string sceneItemId)
+        private void Obs_SceneItemSelected(object sender, SceneItemSelectedEventArgs args)
         {
-            LogMessage($"[SceneItemSelected] Scene: {sceneName} ItemId: {sceneItemId}");
+            LogMessage($"[SceneItemSelected] Scene: {args.SceneName} ItemId: {args.SceneItemId}");
         }
 
         private void Obs_Disconnected(object sender, OBSWebsocketDotNet.Communication.ObsDisconnectionInfo e)
@@ -111,9 +111,9 @@ namespace TestClient
             LogMessage($"[OBS DISCONNECTED] CloseCode: {e.ObsCloseCode} Reason: {e.DisconnectReason} Type: {e.WebsocketDisconnectionInfo?.Type} Exception: {e.WebsocketDisconnectionInfo?.Exception?.Message}");
         }
 
-        private void Obs_StudioModeStateChanged(OBSWebsocket sender, bool studioModeEnabled)
+        private void Obs_StudioModeStateChanged(object sender, StudioModeStateChangedEventArgs args)
         {
-            LogMessage($"[Preview/Studio ModeChanged] Enabled: {studioModeEnabled}");
+            LogMessage($"[Preview/Studio ModeChanged] Enabled: {args.StudioModeEnabled}");
         }
 
         private void Obs_ReplayBufferSaved(OBSWebsocket sender, string savedReplayPath)
@@ -121,9 +121,9 @@ namespace TestClient
             LogMessage($"[ReplayBufferSaved] Save Location: {savedReplayPath}");
         }
 
-        private void Obs_ReplayBufferStateChanged(OBSWebsocket sender, OutputStateChanged outputState)
+        private void Obs_ReplayBufferStateChanged(object sender, ReplayBufferStateChangedEventArgs args)
         {
-            LogMessage($"[ReplayBufferStateChanged] Active: {outputState.IsActive} State: {outputState.StateStr} {outputState.State}");
+            LogMessage($"[ReplayBufferStateChanged] Active: {args.OutputState.IsActive} State: {args.OutputState.StateStr} {args.OutputState.State}");
         }
 
         private void Obs_RecordStateChanged(object sender, RecordStateChangedEventArgs args)
@@ -204,14 +204,14 @@ namespace TestClient
             LogMessage($"[SceneChanged] Current: {args.SceneName}");
         }
 
-        private void Obs_CurrentPreviewSceneChanged(OBSWebsocket sender, string sceneName)
+        private void Obs_CurrentPreviewSceneChanged(object sender, CurrentPreviewSceneChangedEventArgs args)
         {
-            LogMessage($"[Preview/Studio SceneChanged] Current: {sceneName}");
+            LogMessage($"[Preview/Studio SceneChanged] Current: {args.SceneName}");
         }
 
-        private void OBS_onInputVolumeChanged(OBSWebsocket sender, InputVolume volume)
+        private void OBS_onInputVolumeChanged(object sender, InputVolumeChangedEventArgs args)
         {
-            LogMessage($"[SourceVolumeChanged] Source: {volume.InputName} Volume: {volume.InputVolumeMul} VolumeDB: {volume.InputVolumeDb}");
+            LogMessage($"[SourceVolumeChanged] Source: {args.Volume.InputName} Volume: {args.Volume.InputVolumeMul} VolumeDB: {args.Volume.InputVolumeDb}");
         }
 
         private void OBS_onSceneItemEnableStateChanged(object sender, SceneItemEnableStateChangedEventArgs args)

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -86,9 +86,9 @@ namespace TestClient
             obs.VirtualcamStateChanged += Obs_VirtualcamStateChanged;
         }
 
-        private void Obs_InputActiveStateChanged(OBSWebsocket sender, string inputName, bool videoActive)
+        private void Obs_InputActiveStateChanged(object sender, InputActiveStateChangedEventArgs args)
         {
-            LogMessage($"[InputActiveStateChanged] Name: {inputName} Video Active: {videoActive}");
+            LogMessage($"[InputActiveStateChanged] Name: {args.InputName} Video Active: {args.VideoActive}");
         }
 
         private void Obs_InputMuteStateChanged(object sender, InputMuteStateChangedEventArgs args)
@@ -116,9 +116,9 @@ namespace TestClient
             LogMessage($"[Preview/Studio ModeChanged] Enabled: {args.StudioModeEnabled}");
         }
 
-        private void Obs_ReplayBufferSaved(OBSWebsocket sender, string savedReplayPath)
+        private void Obs_ReplayBufferSaved(object sender, ReplayBufferSavedEventArgs args)
         {
-            LogMessage($"[ReplayBufferSaved] Save Location: {savedReplayPath}");
+            LogMessage($"[ReplayBufferSaved] Save Location: {args.SavedReplayPath}");
         }
 
         private void Obs_ReplayBufferStateChanged(object sender, ReplayBufferStateChangedEventArgs args)

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -3,11 +3,9 @@ using OBSWebsocketDotNet;
 using OBSWebsocketDotNet.Types;
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
-using System.Windows.Documents;
 using System.Windows.Forms;
-using static System.TimeZoneInfo;
+using OBSWebsocketDotNet.Types.Events;
 
 namespace TestClient
 {
@@ -187,23 +185,23 @@ namespace TestClient
             LogMessage($"[SceneItemRemoved] Scene: {sourceName} Source: {sourceName} ItemId: {sceneItemId}");
         }
 
-        private void Obs_SceneItemCreated(OBSWebsocket sender, string sceneName, string sourceName, int sceneItemId, int sceneItemIndex)
+        private void Obs_SceneItemCreated(object sender, SceneItemCreatedEventArgs args)
         {
-            LogMessage($"[SceneItemCreated] Scene: {sourceName} Source: {sourceName} ItemId: {sceneItemId} ItemIndex: {sceneItemIndex}");
+            LogMessage($"[SceneItemCreated] Scene: {args.SourceName} Source: {args.SourceName} ItemId: {args.SceneItemId} ItemIndex: {args.SceneItemIndex}");
         }
 
-        private void Obs_SceneListChanged(OBSWebsocket sender, List<JObject> scenes)
+        private void Obs_SceneListChanged(object sender, SceneListChangedEventArgs args)
         {
-            LogMessage($"[SceneListChanged] Count: {scenes.Count}");
-            foreach (var scene in scenes)
+            LogMessage($"[SceneListChanged] Count: {args.Scenes.Count}");
+            foreach (var scene in args.Scenes)
             {
                 LogMessage($"\n{scene}");
             }
         }
 
-        private void Obs_CurrentProgramSceneChanged(OBSWebsocket sender, string newSceneName)
+        private void Obs_CurrentProgramSceneChanged(object sender, ProgramSceneChangedEventArgs args)
         {
-            LogMessage($"[SceneChanged] Current: {newSceneName}");
+            LogMessage($"[SceneChanged] Current: {args.SceneName}");
         }
 
         private void Obs_CurrentPreviewSceneChanged(OBSWebsocket sender, string sceneName)
@@ -235,9 +233,9 @@ namespace TestClient
             }
         }
 
-        private void OBS_onSceneItemListIndexingChanged(OBSWebsocket sender, string sceneName, List<JObject> sceneItems)
+        private void OBS_onSceneItemListIndexingChanged(object sender, SceneItemListReindexedEventArgs args)
         {
-            LogMessage($"[SceneItemListReindexed] Scene: {sceneName}{Environment.NewLine}\tSceneItems: {sceneItems}");
+            LogMessage($"[SceneItemListReindexed] Scene: {args.SceneName}{Environment.NewLine}\tSceneItems: {args.SceneItems}");
         }
 
         private void OBS_onSourceFilterEnableStateChanged(OBSWebsocket sender, string sourceName, string filterName, bool filterEnabled)

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -136,11 +136,10 @@ namespace TestClient
             LogMessage($"[StreamStateChanged] Active: {args.OutputState.IsActive} State: {args.OutputState.StateStr} {args.OutputState.State}");
         }
 
-        private void Obs_VirtualcamStateChanged(OBSWebsocket sender, OutputStateChanged outputState)
+        private void Obs_VirtualcamStateChanged(object sender, VirtualcamStateChangedEventArgs args)
         {
-            LogMessage($"[VirtualcamStateChanged] Active: {outputState.IsActive} State: {outputState.StateStr} {outputState.State}");
+            LogMessage($"[VirtualcamStateChanged] Active: {args.OutputState.IsActive} State: {args.OutputState.StateStr} {args.OutputState.State}");
         }
-
 
         private void Obs_ProfileListChanged(object sender, ProfileListChangedEventArgs args)
         {
@@ -224,10 +223,10 @@ namespace TestClient
             LogMessage($"[SceneItemLockStateChanged] Scene: {args.SceneName} ItemId: {args.SceneItemId} IsLocked: {args.SceneItemLocked}");
         }
 
-        private void OBS_onSourceFilterListReindexed(OBSWebsocket sender, string sourceName, List<FilterReorderItem> filters)
+        private void OBS_onSourceFilterListReindexed(object sender, SourceFilterListReindexedEventArgs args)
         {
-            LogMessage($"[SourceFilterListReindexed] Source: {sourceName}");
-            foreach (var filter in filters)
+            LogMessage($"[SourceFilterListReindexed] Source: {args.SourceName}");
+            foreach (var filter in args.Filters)
             {
                 LogMessage($"\t{filter.Name}");
             }
@@ -238,19 +237,19 @@ namespace TestClient
             LogMessage($"[SceneItemListReindexed] Scene: {args.SceneName}{Environment.NewLine}\tSceneItems: {args.SceneItems}");
         }
 
-        private void OBS_onSourceFilterEnableStateChanged(OBSWebsocket sender, string sourceName, string filterName, bool filterEnabled)
+        private void OBS_onSourceFilterEnableStateChanged(object sender, SourceFilterEnableStateChangedEventArgs args)
         {
-            LogMessage($"[SourceFilterEnableStateChanged] Source: {sourceName} Filter: {filterName} Enabled: {filterEnabled}");
+            LogMessage($"[SourceFilterEnableStateChanged] Source: {args.SourceName} Filter: {args.FilterName} Enabled: {args.FilterEnabled}");
         }
 
-        private void OBS_onSourceFilterRemoved(OBSWebsocket sender, string sourceName, string filterName)
+        private void OBS_onSourceFilterRemoved(object sender, SourceFilterRemovedEventArgs args)
         {
-            LogMessage($"[SourceFilterRemoved] Source: {sourceName} Filter: {filterName}");
+            LogMessage($"[SourceFilterRemoved] Source: {args.SourceName} Filter: {args.FilterName}");
         }
 
-        private void OBS_onSourceFilterCreated(OBSWebsocket sender, string sourceName, string filterName, string filterKind, int filterIndex, JObject filterSettings, JObject defaultFilterSettings)
+        private void OBS_onSourceFilterCreated(object sender, SourceFilterCreatedEventArgs args)
         {
-            LogMessage($"[SourceFilterCreated] Source: {sourceName} Filter: {filterName} FilterKind: {filterKind} FilterIndex: {filterIndex}{Environment.NewLine}\tSettings: {filterSettings}{Environment.NewLine}\tDefaultSettings: {defaultFilterSettings}");
+            LogMessage($"[SourceFilterCreated] Source: {args.SourceName} Filter: {args.FilterName} FilterKind: {args.FilterKind} FilterIndex: {args.FilterIndex}{Environment.NewLine}\tSettings: {args.FilterSettings}{Environment.NewLine}\tDefaultSettings: {args.DefaultFilterSettings}");
         }
 
         private void OBS_onSceneTransitionVideoEnded(object sender, SceneTransitionVideoEndedEventArgs args)

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -180,9 +180,9 @@ namespace TestClient
             LogMessage($"[CurrentSceneCollectionChanged] Current: {sceneCollectionName}");
         }
 
-        private void Obs_SceneItemRemoved(OBSWebsocket sender, string sceneName, string sourceName, int sceneItemId)
+        private void Obs_SceneItemRemoved(object sender, SceneItemRemovedEventArgs args)
         {
-            LogMessage($"[SceneItemRemoved] Scene: {sourceName} Source: {sourceName} ItemId: {sceneItemId}");
+            LogMessage($"[SceneItemRemoved] Scene: {args.SourceName} Source: {args.SourceName} ItemId: {args.SceneItemId}");
         }
 
         private void Obs_SceneItemCreated(object sender, SceneItemCreatedEventArgs args)
@@ -214,14 +214,14 @@ namespace TestClient
             LogMessage($"[SourceVolumeChanged] Source: {volume.InputName} Volume: {volume.InputVolumeMul} VolumeDB: {volume.InputVolumeDb}");
         }
 
-        private void OBS_onSceneItemEnableStateChanged(OBSWebsocket sender, string sceneName, int sceneItemId, bool sceneItemEnabled)
+        private void OBS_onSceneItemEnableStateChanged(object sender, SceneItemEnableStateChangedEventArgs args)
         {
-            LogMessage($"[SceneItemEnableStateChanged] Scene: {sceneName} ItemId: {sceneItemId} Enabled?: {sceneItemEnabled}");
+            LogMessage($"[SceneItemEnableStateChanged] Scene: {args.SceneName} ItemId: {args.SceneItemId} Enabled?: {args.SceneItemEnabled}");
         }
 
-        private void OBS_onSceneItemLockStateChanged(OBSWebsocket sender, string sceneName, int scenItemId, bool sceneItemLocked)
+        private void OBS_onSceneItemLockStateChanged(object sender, SceneItemLockStateChangedEventArgs args)
         {
-            LogMessage($"[SceneItemLockStateChanged] Scene: {sceneName} ItemId: {scenItemId} IsLocked: {sceneItemLocked}");
+            LogMessage($"[SceneItemLockStateChanged] Scene: {args.SceneName} ItemId: {args.SceneItemId} IsLocked: {args.SceneItemLocked}");
         }
 
         private void OBS_onSourceFilterListReindexed(OBSWebsocket sender, string sourceName, List<FilterReorderItem> filters)

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -151,14 +151,14 @@ namespace TestClient
             }
         }
 
-        private void Obs_CurrentProfileChanged(OBSWebsocket sender, string profileName)
+        private void Obs_CurrentProfileChanged(object sender, CurrentProfileChangedEventArgs args)
         {
-            LogMessage($"[CurrentProfileChanged] Current: {profileName}");
+            LogMessage($"[CurrentProfileChanged] Current: {args.ProfileName}");
         }
 
-        private void Obs_CurrentSceneTransitionDurationChanged(OBSWebsocket sender, int transitionDuration)
+        private void Obs_CurrentSceneTransitionDurationChanged(object sender, CurrentSceneTransitionDurationChangedEventArgs args)
         {
-            LogMessage($"[CurrentSceneTransitionDurationChanged] Current: {transitionDuration}");
+            LogMessage($"[CurrentSceneTransitionDurationChanged] Current: {args.TransitionDuration}");
         }
 
         private void Obs_CurrentSceneTransitionChanged(object sender, CurrentSceneTransitionChangedEventArgs args)
@@ -253,19 +253,19 @@ namespace TestClient
             LogMessage($"[SourceFilterCreated] Source: {sourceName} Filter: {filterName} FilterKind: {filterKind} FilterIndex: {filterIndex}{Environment.NewLine}\tSettings: {filterSettings}{Environment.NewLine}\tDefaultSettings: {defaultFilterSettings}");
         }
 
-        private void OBS_onSceneTransitionVideoEnded(OBSWebsocket sender, string transitionName)
+        private void OBS_onSceneTransitionVideoEnded(object sender, SceneTransitionVideoEndedEventArgs args)
         {
-            LogMessage($"[SceneTransitionVideoEnded] Name: {transitionName}");
+            LogMessage($"[SceneTransitionVideoEnded] Name: {args.TransitionName}");
         }
 
-        private void OBS_onSceneTransitionEnded(OBSWebsocket sender, string transitionName)
+        private void OBS_onSceneTransitionEnded(object sender, SceneTransitionEndedEventArgs args)
         {
-            LogMessage($"[SceneTransitionEnded] Name: {transitionName}");
+            LogMessage($"[SceneTransitionEnded] Name: {args.TransitionName}");
         }
 
-        private void OBS_onSceneTransitionStarted(OBSWebsocket sender, string transitionName)
+        private void OBS_onSceneTransitionStarted(object sender, SceneTransitionStartedEventArgs args)
         {
-            LogMessage($"[SceneTransitionStarted] Name: {transitionName}");
+            LogMessage($"[SceneTransitionStarted] Name: {args.TransitionName}");
         }
 
         private void LogMessage(string message)

--- a/TestClient/AdvancedWindow.cs
+++ b/TestClient/AdvancedWindow.cs
@@ -161,23 +161,23 @@ namespace TestClient
             LogMessage($"[CurrentSceneTransitionDurationChanged] Current: {transitionDuration}");
         }
 
-        private void Obs_CurrentSceneTransitionChanged(OBSWebsocket sender, string transitionName)
+        private void Obs_CurrentSceneTransitionChanged(object sender, CurrentSceneTransitionChangedEventArgs args)
         {
-            LogMessage($"[CurrentSceneTransitionChanged] Current: {transitionName}");
+            LogMessage($"[CurrentSceneTransitionChanged] Current: {args.TransitionName}");
         }
 
-        private void Obs_SceneCollectionListChanged(OBSWebsocket sender, List<string> sceneCollections)
+        private void Obs_SceneCollectionListChanged(object sender, SceneCollectionListChangedEventArgs args)
         {
-            LogMessage($"[SceneCollectionListChanged] Count: {sceneCollections.Count}");
-            foreach (var sc in sceneCollections)
+            LogMessage($"[SceneCollectionListChanged] Count: {args.SceneCollections.Count}");
+            foreach (var sc in args.SceneCollections)
             {
                 LogMessage($"\t{sc}");
             }
         }
 
-        private void Obs_CurrentSceneCollectionChanged(OBSWebsocket sender, string sceneCollectionName)
+        private void Obs_CurrentSceneCollectionChanged(object sender, CurrentSceneCollectionChangedEventArgs args)
         {
-            LogMessage($"[CurrentSceneCollectionChanged] Current: {sceneCollectionName}");
+            LogMessage($"[CurrentSceneCollectionChanged] Current: {args.SceneCollectionName}");
         }
 
         private void Obs_SceneItemRemoved(object sender, SceneItemRemovedEventArgs args)

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -88,21 +88,21 @@ namespace TestClient
                 var streamStatus = obs.GetStreamStatus();
                 if (streamStatus.IsActive)
                 {
-                    onStreamStateChanged(obs, new OutputStateChanged() { IsActive = true, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STARTED) });
+                    onStreamStateChanged(obs, new StreamStateChangedEventArgs(new OutputStateChanged() { IsActive = true, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STARTED) }));
                 }
                 else
                 {
-                    onStreamStateChanged(obs, new OutputStateChanged() { IsActive = false, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED) });
+                    onStreamStateChanged(obs, new StreamStateChangedEventArgs(new OutputStateChanged() { IsActive = false, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED) }));
                 }
 
                 var recordStatus = obs.GetRecordStatus();
                 if (recordStatus.IsRecording)
                 {
-                    onRecordStateChanged(obs, new OutputStateChanged() { IsActive = true, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STARTED) });
+                    onRecordStateChanged(obs, new RecordStateChangedEventArgs(new RecordStateChanged() { IsActive = true, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STARTED) }));
                 }
                 else
                 {
-                    onRecordStateChanged(obs, new OutputStateChanged() { IsActive = false, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED) });
+                    onRecordStateChanged(obs, new RecordStateChangedEventArgs(new RecordStateChanged() { IsActive = false, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED) }));
                 }
 
                 var camStatus = obs.GetVirtualCamStatus();
@@ -233,10 +233,10 @@ namespace TestClient
             });
         }
 
-        private void onStreamStateChanged(OBSWebsocket sender, OutputStateChanged outputState)
+        private void onStreamStateChanged(object sender, StreamStateChangedEventArgs args)
         {
             string state = "";
-            switch (outputState.State)
+            switch (args.OutputState.State)
             {
                 case OutputState.OBS_WEBSOCKET_OUTPUT_STARTING:
                     state = "Stream starting...";
@@ -265,10 +265,10 @@ namespace TestClient
             });
         }
 
-        private void onRecordStateChanged(OBSWebsocket sender, OutputStateChanged outputState)
+        private void onRecordStateChanged(object sender, RecordStateChangedEventArgs args)
         {
             string state = "";
-            switch (outputState.State)
+            switch (args.OutputState.State)
             {
                 case OutputState.OBS_WEBSOCKET_OUTPUT_STARTING:
                     state = "Recording starting...";

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -209,7 +209,7 @@ namespace TestClient
             });
         }
 
-        private void onCurrentProfileChanged(object sender, string profileName)
+        private void onCurrentProfileChanged(object sender, CurrentProfileChangedEventArgs args)
         {
             BeginInvoke((MethodInvoker)delegate
             {
@@ -225,11 +225,11 @@ namespace TestClient
             });
         }
 
-        private void onCurrentSceneTransitionDurationChanged(OBSWebsocket sender, int newDuration)
+        private void onCurrentSceneTransitionDurationChanged(object sender, CurrentSceneTransitionDurationChangedEventArgs args)
         {
             BeginInvoke((MethodInvoker)delegate
             {
-                tbTransitionDuration.Value = newDuration;
+                tbTransitionDuration.Value = args.TransitionDuration;
             });
         }
 

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -108,11 +108,11 @@ namespace TestClient
                 var camStatus = obs.GetVirtualCamStatus();
                 if (camStatus.IsActive)
                 {
-                    onVirtualCamStateChanged(this, new OutputStateChanged() { IsActive = true, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STARTED) });
+                    onVirtualCamStateChanged(this, new VirtualcamStateChangedEventArgs(new OutputStateChanged() { IsActive = true, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STARTED) }));
                 }
                 else
                 {
-                    onVirtualCamStateChanged(this, new OutputStateChanged() { IsActive = false, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED) });
+                    onVirtualCamStateChanged(this, new VirtualcamStateChangedEventArgs(new OutputStateChanged() { IsActive = false, StateStr = nameof(OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED) }));
                 }
 
                 keepAliveTokenSource = new CancellationTokenSource();
@@ -493,10 +493,10 @@ namespace TestClient
             //obs.SetRecordingFolder(tbFolderPath.Text);
         }
 
-        private void onVirtualCamStateChanged(object sender, OutputStateChanged outputState)
+        private void onVirtualCamStateChanged(object sender, VirtualcamStateChangedEventArgs args)
         {
             string state = "";
-            switch (outputState.State)
+            switch (args.OutputState.State)
             {
                 case OutputState.OBS_WEBSOCKET_OUTPUT_STARTING:
                     state = "VirtualCam starting...";

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -24,6 +24,7 @@ using System.Windows.Forms;
 using System.Linq;
 using OBSWebsocketDotNet;
 using OBSWebsocketDotNet.Types;
+using OBSWebsocketDotNet.Types.Events;
 
 namespace TestClient
 {
@@ -192,11 +193,11 @@ namespace TestClient
 
         }
 
-        private void onCurrentProgramSceneChanged(OBSWebsocket sender, string newSceneName)
+        private void onCurrentProgramSceneChanged(object sender, ProgramSceneChangedEventArgs args)
         {
             BeginInvoke((MethodInvoker)delegate
             {
-                tbCurrentScene.Text = newSceneName;
+                tbCurrentScene.Text = args.SceneName;
             });
         }
 

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -201,7 +201,7 @@ namespace TestClient
             });
         }
 
-        private void onSceneCollectionChanged(object sender, string sceneCollectionName)
+        private void onSceneCollectionChanged(object sender, CurrentSceneCollectionChangedEventArgs args)
         {
             BeginInvoke((MethodInvoker)delegate
             {
@@ -217,11 +217,11 @@ namespace TestClient
             });
         }
 
-        private void onCurrentSceneTransitionChanged(OBSWebsocket sender, string newTransitionName)
+        private void onCurrentSceneTransitionChanged(object sender, CurrentSceneTransitionChangedEventArgs args)
         {
             BeginInvoke((MethodInvoker)delegate
             {
-                tbTransition.Text = newTransitionName;
+                tbTransition.Text = args.TransitionName;
             });
         }
 

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -10,45 +10,6 @@ using OBSWebsocketDotNet.Types.Events;
 namespace OBSWebsocketDotNet
 {
     #region EventDelegates
-    
-    
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene where the item is</param>
-    /// <param name="sourceName">Name of the concerned item</param>
-    /// <param name="sceneItemId">Numeric ID of the scene item</param>
-    /// <param name="sceneItemIndex">Index position of the item</param>
-    public delegate void SceneItemCreatedCallback(OBSWebsocket sender, string sceneName, string sourceName, int sceneItemId, int sceneItemIndex);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneItemRemoved"/>
-    /// A scene item has been removed.
-    /// This event is not emitted when the scene the item is in is removed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene the item was removed from</param>
-    /// <param name="sourceName">Name of the underlying source (input/scene)</param>
-    /// <param name="sceneItemId">Numeric ID of the scene item</param>
-    public delegate void SceneItemRemovedCallback(OBSWebsocket sender, string sceneName, string sourceName, int sceneItemId);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneItemEnableStateChanged"/>
-    /// A scene item's enable state has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene the item is in</param>
-    /// <param name="sceneItemId">Numeric ID of the scene item</param>
-    /// <param name="sceneItemEnabled">Whether the scene item is enabled (visible)</param>
-    public delegate void SceneItemEnableStateChangedCallback(OBSWebsocket sender, string sceneName, int sceneItemId, bool sceneItemEnabled);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneItemLockStateChanged"/>
-    /// A scene item's lock state has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene the item is in</param>
-    /// <param name="sceneItemId">Numeric ID of the scene item</param>
-    /// <param name="sceneItemLocked">Whether the scene item is locked</param>
-    public delegate void SceneItemLockStateChangedCallback(OBSWebsocket sender, string sceneName, int sceneItemId, bool sceneItemLocked);
 
     /// <summary>
     /// Called by <see cref="OBSWebsocket.CurrentSceneCollectionChanged"/>
@@ -475,17 +436,17 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Triggered when an item is removed from the item list of the specified scene
         /// </summary>
-        public event SceneItemRemovedCallback SceneItemRemoved;
+        public event EventHandler<SceneItemRemovedEventArgs> SceneItemRemoved;
 
         /// <summary>
         /// Triggered when the visibility of a scene item changes
         /// </summary>
-        public event SceneItemEnableStateChangedCallback SceneItemEnableStateChanged;
+        public event EventHandler<SceneItemEnableStateChangedEventArgs> SceneItemEnableStateChanged;
 
         /// <summary>
         /// Triggered when the lock status of a scene item changes
         /// </summary>
-        public event SceneItemLockStateChangedCallback SceneItemLockStateChanged;
+        public event EventHandler<SceneItemLockStateChangedEventArgs> SceneItemLockStateChanged;
 
         /// <summary>
         /// Triggered when switching to another scene collection
@@ -760,15 +721,15 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(SceneItemRemoved):
-                    SceneItemRemoved?.Invoke(this, (string)body["sceneName"], (string)body["sourceName"], (int)body["sceneItemId"]);
+                    SceneItemRemoved?.Invoke(this, new SceneItemRemovedEventArgs((string)body["sceneName"], (string)body["sourceName"], (int)body["sceneItemId"]));
                     break;
 
                 case nameof(SceneItemEnableStateChanged):
-                    SceneItemEnableStateChanged?.Invoke(this, (string)body["sceneName"], (int)body["sceneItemId"], (bool)body["sceneItemEnabled"]);
+                    SceneItemEnableStateChanged?.Invoke(this, new SceneItemEnableStateChangedEventArgs((string)body["sceneName"], (int)body["sceneItemId"], (bool)body["sceneItemEnabled"]));
                     break;
 
                 case nameof(SceneItemLockStateChanged):
-                    SceneItemLockStateChanged?.Invoke(this, (string)body["sceneName"], (int)body["sceneItemId"], (bool)body["sceneItemLocked"]);
+                    SceneItemLockStateChanged?.Invoke(this, new SceneItemLockStateChangedEventArgs((string)body["sceneName"], (int)body["sceneItemId"], (bool)body["sceneItemLocked"]));
                     break;
 
                 case nameof(CurrentSceneCollectionChanged):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -10,92 +10,7 @@ using OBSWebsocketDotNet.Types.Events;
 namespace OBSWebsocketDotNet
 {
     #region EventDelegates
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SourceFilterRemoved"/>
-    /// A filter has been removed from a source.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sourceName">Name of the source the filter was on</param>
-    /// <param name="filterName">Name of the filter</param>
-    public delegate void SourceFilterRemovedCallback(OBSWebsocket sender, string sourceName, string filterName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SourceFilterCreated"/>
-    /// A filter has been added to a source.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sourceName">Name of the source the filter was added to</param>
-    /// <param name="filterName">Name of the filter</param>
-    /// <param name="filterKind">The kind of the filter</param>
-    /// <param name="filterIndex">Index position of the filter</param>
-    /// <param name="filterSettings">The settings configured to the filter when it was created</param>
-    /// <param name="defaultFilterSettings">The default settings for the filter</param>
-    public delegate void SourceFilterCreatedCallback(OBSWebsocket sender, string sourceName, string filterName, string filterKind, int filterIndex, JObject filterSettings, JObject defaultFilterSettings);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SourceFilterListReindexed"/>
-    /// A source's filter list has been reindexed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sourceName">Name of the source</param>
-    /// <param name="filters">Array of filter objects</param>
-    public delegate void SourceFilterListReindexedCallback(OBSWebsocket sender, string sourceName, List<FilterReorderItem> filters);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SourceFilterEnableStateChanged"/>
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sourceName">Name of the source the filter is on</param>
-    /// <param name="filterName">Name of the filter</param>
-    /// <param name="filterEnabled">Whether the filter is enabled</param>
-    public delegate void SourceFilterEnableStateChangedCallback(OBSWebsocket sender, string sourceName, string filterName, bool filterEnabled);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.VendorEvent"/>
-    /// An event has been emitted from a vendor.
-    /// A vendor is a unique name registered by a third-party plugin or script, which allows for custom requests and events to be added to obs-websocket.
-    /// If a plugin or script implements vendor requests or events, documentation is expected to be provided with them.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="vendorName">Name of the vendor emitting the event</param>
-    /// <param name="eventType">Vendor-provided event typedef</param>
-    /// <param name="eventData">Vendor-provided event data. {} if event does not provide any data</param>
-    public delegate void VendorEventCallback(OBSWebsocket sender, string vendorName, string eventType, JObject eventData);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.MediaInputPlaybackEnded"/>
-    /// A media input has finished playing.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    public delegate void MediaInputPlaybackEndedCallback(OBSWebsocket sender, string inputName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.MediaInputPlaybackStarted"/>
-    /// A media input has started playing.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    public delegate void MediaInputPlaybackStartedCallback(OBSWebsocket sender, string inputName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.MediaInputActionTriggered"/>
-    /// An action has been performed on an input.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="mediaAction">Action performed on the input. See `ObsMediaInputAction` enum</param>
-    public delegate void MediaInputActionTriggeredCallback(OBSWebsocket sender, string inputName, string mediaAction);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.VirtualcamStateChanged"/>
-    /// The state of the virtualcam output has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="outputState">The specific state of the output</param>
-    public delegate void VirtualcamStateChangedCallback(OBSWebsocket sender, OutputStateChanged outputState);
-
+    
     /// <summary>
     /// Callback by <see cref="OBSWebsocket.CurrentSceneCollectionChanging"/>
     /// The current scene collection has begun changing.
@@ -391,22 +306,22 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// A filter was added to a source
         /// </summary>
-        public event SourceFilterCreatedCallback SourceFilterCreated;
+        public event EventHandler<SourceFilterCreatedEventArgs> SourceFilterCreated;
 
         /// <summary>
         /// A filter was removed from a source
         /// </summary>
-        public event SourceFilterRemovedCallback SourceFilterRemoved;
+        public event EventHandler<SourceFilterRemovedEventArgs> SourceFilterRemoved;
 
         /// <summary>
         /// Filters in a source have been reordered
         /// </summary>
-        public event SourceFilterListReindexedCallback SourceFilterListReindexed;
+        public event EventHandler<SourceFilterListReindexedEventArgs> SourceFilterListReindexed;
 
         /// <summary>
         /// Triggered when the visibility of a filter has changed
         /// </summary>
-        public event SourceFilterEnableStateChangedCallback SourceFilterEnableStateChanged;
+        public event EventHandler<SourceFilterEnableStateChangedEventArgs> SourceFilterEnableStateChanged;
 
         /// <summary>
         /// A source has been muted or unmuted
@@ -421,27 +336,27 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// A custom broadcast message was received
         /// </summary>
-        public event VendorEventCallback VendorEvent;
+        public event EventHandler<VendorEventArgs> VendorEvent;
 
         /// <summary>
         /// These events are emitted by the OBS sources themselves. For example when the media file ends. The behavior depends on the type of media source being used.
         /// </summary>
-        public event MediaInputPlaybackEndedCallback MediaInputPlaybackEnded;
+        public event EventHandler<MediaInputPlaybackEndedEventArgs> MediaInputPlaybackEnded;
 
         /// <summary>
         /// These events are emitted by the OBS sources themselves. For example when the media file starts playing. The behavior depends on the type of media source being used.
         /// </summary>
-        public event MediaInputPlaybackStartedCallback MediaInputPlaybackStarted;
+        public event EventHandler<MediaInputPlaybackStartedEventArgs> MediaInputPlaybackStarted;
 
         /// <summary>
         /// This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
         /// </summary>
-        public event MediaInputActionTriggeredCallback MediaInputActionTriggered;
+        public event EventHandler<MediaInputActionTriggeredEventArgs> MediaInputActionTriggered;
 
         /// <summary>
         /// The virtual cam state has changed.
         /// </summary>
-        public event VirtualcamStateChangedCallback VirtualcamStateChanged;
+        public event EventHandler<VirtualcamStateChangedEventArgs> VirtualcamStateChanged;
 
         /// <summary>
         /// The current scene collection has begun changing.
@@ -653,11 +568,11 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(SourceFilterCreated):
-                    SourceFilterCreated?.Invoke(this, (string)body["sourceName"], (string)body["filterName"], (string)body["filterKind"], (int)body["filterIndex"], (JObject)body["filterSettings"], (JObject)body["defaultFilterSettings"]);
+                    SourceFilterCreated?.Invoke(this, new SourceFilterCreatedEventArgs((string)body["sourceName"], (string)body["filterName"], (string)body["filterKind"], (int)body["filterIndex"], (JObject)body["filterSettings"], (JObject)body["defaultFilterSettings"]));
                     break;
 
                 case nameof(SourceFilterRemoved):
-                    SourceFilterRemoved?.Invoke(this, (string)body["sourceName"], (string)body["filterName"]);
+                    SourceFilterRemoved?.Invoke(this, new SourceFilterRemovedEventArgs((string)body["sourceName"], (string)body["filterName"]));
                     break;
 
                 case nameof(SourceFilterListReindexed):
@@ -666,32 +581,32 @@ namespace OBSWebsocketDotNet
                         List<FilterReorderItem> filters = new List<FilterReorderItem>();
                         JsonConvert.PopulateObject(body["filters"].ToString(), filters);
 
-                        SourceFilterListReindexed?.Invoke(this, (string)body["sourceName"], filters);
+                        SourceFilterListReindexed?.Invoke(this, new SourceFilterListReindexedEventArgs((string)body["sourceName"], filters));
                     }
                     break;
 
                 case nameof(SourceFilterEnableStateChanged):
-                    SourceFilterEnableStateChanged?.Invoke(this, (string)body["sourceName"], (string)body["filterName"], (bool)body["filterEnabled"]);
+                    SourceFilterEnableStateChanged?.Invoke(this, new SourceFilterEnableStateChangedEventArgs((string)body["sourceName"], (string)body["filterName"], (bool)body["filterEnabled"]));
                     break;
 
                 case nameof(VendorEvent):
-                    VendorEvent?.Invoke(this, (string)body["vendorName"], (string)body["eventType"], body);
+                    VendorEvent?.Invoke(this, new VendorEventArgs((string)body["vendorName"], (string)body["eventType"], body));
                     break;
 
                 case nameof(MediaInputPlaybackEnded):
-                    MediaInputPlaybackEnded?.Invoke(this, (string)body["inputName"]);
+                    MediaInputPlaybackEnded?.Invoke(this, new MediaInputPlaybackEndedEventArgs((string)body["inputName"]));
                     break;
 
                 case nameof(MediaInputPlaybackStarted):
-                    MediaInputPlaybackStarted?.Invoke(this, (string)body["sourceName"]);
+                    MediaInputPlaybackStarted?.Invoke(this, new MediaInputPlaybackStartedEventArgs((string)body["sourceName"]));
                     break;
 
                 case nameof(MediaInputActionTriggered):
-                    MediaInputActionTriggered?.Invoke(this, (string)body["inputName"], (string)body["mediaAction"]);
+                    MediaInputActionTriggered?.Invoke(this, new MediaInputActionTriggeredEventArgs((string)body["inputName"], (string)body["mediaAction"]));
                     break;
 
                 case nameof(VirtualcamStateChanged):
-                    VirtualcamStateChanged?.Invoke(this, new OutputStateChanged(body));
+                    VirtualcamStateChanged?.Invoke(this, new VirtualcamStateChangedEventArgs(new OutputStateChanged(body)));
                     break;
 
                 case nameof(CurrentSceneCollectionChanging):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -5,37 +5,13 @@ using OBSWebsocketDotNet.Types;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using OBSWebsocketDotNet.Types.Events;
 
 namespace OBSWebsocketDotNet
 {
     #region EventDelegates
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.CurrentProgramSceneChanged"/>
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="newSceneName">Name of the new current scene</param>
-    public delegate void CurrentProgramSceneChangeCallback(OBSWebsocket sender, string newSceneName);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneListChanged"/>
-    /// The list of scenes has changed.
-    /// TODO: Make OBS fire this event when scenes are reordered.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="scenes">Updated array of scenes</param>
-    public delegate void SceneListChangedCallback(OBSWebsocket sender, List<JObject> scenes);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneItemListReindexed"/>
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene where items where reordered</param>
-    /// /// <param name="sceneItems">List of all scene items as JObject</param>
-    public delegate void SceneItemListReindexedCallback(OBSWebsocket sender, string sceneName, List<JObject> sceneItems);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneItemCreated"/>
-    /// </summary>
+    
+    
     /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
     /// <param name="sceneName">Name of the scene where the item is</param>
     /// <param name="sourceName">Name of the concerned item</param>
@@ -478,23 +454,23 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// The current program scene has changed.
         /// </summary>
-        public event CurrentProgramSceneChangeCallback CurrentProgramSceneChanged;
+        public event EventHandler<ProgramSceneChangedEventArgs> CurrentProgramSceneChanged;
 
         /// <summary>
         /// The list of scenes has changed.
         /// TODO: Make OBS fire this event when scenes are reordered.
         /// </summary>
-        public event SceneListChangedCallback SceneListChanged;
+        public event EventHandler<SceneListChangedEventArgs> SceneListChanged;
 
         /// <summary>
         /// Triggered when the scene item list of the specified scene is reordered
         /// </summary>
-        public event SceneItemListReindexedCallback SceneItemListReindexed;
+        public event EventHandler<SceneItemListReindexedEventArgs> SceneItemListReindexed;
 
         /// <summary>
         /// Triggered when a new item is added to the item list of the specified scene
         /// </summary>
-        public event SceneItemCreatedCallback SceneItemCreated;
+        public event EventHandler<SceneItemCreatedEventArgs> SceneItemCreated;
 
         /// <summary>
         /// Triggered when an item is removed from the item list of the specified scene
@@ -768,19 +744,19 @@ namespace OBSWebsocketDotNet
             switch (eventType)
             {
                 case nameof(CurrentProgramSceneChanged):
-                    CurrentProgramSceneChanged?.Invoke(this, (string)body["sceneName"]);
+                    CurrentProgramSceneChanged?.Invoke(this, new ProgramSceneChangedEventArgs((string)body["sceneName"]));
                     break;
 
                 case nameof(SceneListChanged):
-                    SceneListChanged?.Invoke(this, JsonConvert.DeserializeObject<List<JObject>>((string)body["scenes"]));
+                    SceneListChanged?.Invoke(this, new SceneListChangedEventArgs(JsonConvert.DeserializeObject<List<JObject>>((string)body["scenes"])));
                     break;
 
                 case nameof(SceneItemListReindexed):
-                    SceneItemListReindexed?.Invoke(this, (string)body["sceneName"], JsonConvert.DeserializeObject<List<JObject>>((string)body["sceneItems"]));
+                    SceneItemListReindexed?.Invoke(this, new SceneItemListReindexedEventArgs((string)body["sceneName"], JsonConvert.DeserializeObject<List<JObject>>((string)body["sceneItems"])));
                     break;
 
                 case nameof(SceneItemCreated):
-                    SceneItemCreated?.Invoke(this, (string)body["sceneName"], (string)body["sourceName"], (int)body["sceneItemId"], (int)body["sceneItemIndex"]);
+                    SceneItemCreated?.Invoke(this, new SceneItemCreatedEventArgs((string)body["sceneName"], (string)body["sourceName"], (int)body["sceneItemId"], (int)body["sceneItemIndex"]));
                     break;
 
                 case nameof(SceneItemRemoved):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -12,50 +12,6 @@ namespace OBSWebsocketDotNet
     #region EventDelegates
 
     /// <summary>
-    /// Called by <see cref="OBSWebsocket.CurrentSceneTransitionDurationChanged"/>
-    /// The current scene transition duration has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="transitionDuration">Transition duration in milliseconds</param>
-    public delegate void CurrentSceneTransitionDurationChangedCallback(OBSWebsocket sender, int transitionDuration);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneTransitionStarted"/>
-    /// A scene transition has started.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="transitionName">Transition name</param>
-    public delegate void SceneTransitionStartedCallback(OBSWebsocket sender, string transitionName);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneTransitionEnded"/>
-    /// A scene transition has completed fully.
-    /// Note: Does not appear to trigger when the transition is interrupted by the user.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="transitionName">Scene transition name</param>
-    public delegate void SceneTransitionEndedCallback(OBSWebsocket sender, string transitionName);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneTransitionVideoEnded"/>
-    /// A scene transition's video has completed fully.
-    /// Useful for stinger transitions to tell when the video *actually* ends.
-    /// `SceneTransitionEnded` only signifies the cut point, not the completion of transition playback.
-    /// Note: Appears to be called by every transition, regardless of relevance.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="transitionName">Scene transition name</param>
-    public delegate void SceneTransitionVideoEndedCallback(OBSWebsocket sender, string transitionName);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.CurrentProfileChanged"/>
-    /// The current profile has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="profileName">Name of the new profile</param>
-    public delegate void CurrentProfileChangedCallback(OBSWebsocket sender, string profileName);
-
-    /// <summary>
     /// Called by <see cref="OBSWebsocket.ProfileListChanged"/>
     /// The profile list has changed.
     /// </summary>
@@ -441,27 +397,27 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Triggered when the current transition duration is changed
         /// </summary>
-        public event CurrentSceneTransitionDurationChangedCallback CurrentSceneTransitionDurationChanged;
+        public event EventHandler<CurrentSceneTransitionDurationChangedEventArgs> CurrentSceneTransitionDurationChanged;
 
         /// <summary>
         /// Triggered when a transition between two scenes starts. Followed by <see cref="CurrentProgramSceneChanged"/>
         /// </summary>
-        public event SceneTransitionStartedCallback SceneTransitionStarted;
+        public event EventHandler<SceneTransitionStartedEventArgs> SceneTransitionStarted;
 
         /// <summary>
         /// Triggered when a transition (other than "cut") has ended. Please note that the from-scene field is not available in TransitionEnd
         /// </summary>
-        public event SceneTransitionEndedCallback SceneTransitionEnded;
+        public event EventHandler<SceneTransitionEndedEventArgs> SceneTransitionEnded;
 
         /// <summary>
         /// Triggered when a stinger transition has finished playing its video
         /// </summary>
-        public event SceneTransitionVideoEndedCallback SceneTransitionVideoEnded;
+        public event EventHandler<SceneTransitionVideoEndedEventArgs> SceneTransitionVideoEnded;
 
         /// <summary>
         /// Triggered when switching to another profile
         /// </summary>
-        public event CurrentProfileChangedCallback CurrentProfileChanged;
+        public event EventHandler<CurrentProfileChangedEventArgs> CurrentProfileChanged;
 
         /// <summary>
         /// Triggered when a profile is created, imported, removed or renamed
@@ -720,23 +676,23 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(CurrentSceneTransitionDurationChanged):
-                    CurrentSceneTransitionDurationChanged?.Invoke(this, (int)body["transitionDuration"]);
+                    CurrentSceneTransitionDurationChanged?.Invoke(this, new CurrentSceneTransitionDurationChangedEventArgs((int)body["transitionDuration"]));
                     break;
 
                 case nameof(SceneTransitionStarted):
-                    SceneTransitionStarted?.Invoke(this, (string)body["transitionName"]);
+                    SceneTransitionStarted?.Invoke(this, new SceneTransitionStartedEventArgs((string)body["transitionName"]));
                     break;
 
                 case nameof(SceneTransitionEnded):
-                    SceneTransitionEnded?.Invoke(this, (string)body["transitionName"]);
+                    SceneTransitionEnded?.Invoke(this, new SceneTransitionEndedEventArgs((string)body["transitionName"]));
                     break;
 
                 case nameof(SceneTransitionVideoEnded):
-                    SceneTransitionVideoEnded?.Invoke(this, (string)body["transitionName"]);
+                    SceneTransitionVideoEnded?.Invoke(this, new SceneTransitionVideoEndedEventArgs((string)body["transitionName"]));
                     break;
 
                 case nameof(CurrentProfileChanged):
-                    CurrentProfileChanged?.Invoke(this, (string)body["profileName"]);
+                    CurrentProfileChanged?.Invoke(this, new CurrentProfileChangedEventArgs((string)body["profileName"]));
                     break;
 
                 case nameof(ProfileListChanged):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -12,31 +12,6 @@ namespace OBSWebsocketDotNet
     #region EventDelegates
 
     /// <summary>
-    /// Called by <see cref="OBSWebsocket.CurrentSceneCollectionChanged"/>
-    /// The current scene collection has changed.
-    /// Note: If polling has been paused during `CurrentSceneCollectionChanging`, this is the que to restart polling.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneCollectionName">Name of the new scene collection</param>
-    public delegate void CurrentSceneCollectionChangedCallback(OBSWebsocket sender, string sceneCollectionName);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.SceneCollectionListChanged"/>
-    /// The scene collection list has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneCollections">Updated list of scene collections</param>
-    public delegate void SceneCollectionListChangedCallback(OBSWebsocket sender, List<string> sceneCollections);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.CurrentSceneTransitionChanged"/>
-    /// The current scene transition has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="transitionName">Name of the new transition</param>
-    public delegate void CurrentSceneTransitionChangedCallback(OBSWebsocket sender, string transitionName);
-
-    /// <summary>
     /// Called by <see cref="OBSWebsocket.CurrentSceneTransitionDurationChanged"/>
     /// The current scene transition duration has changed.
     /// </summary>
@@ -451,17 +426,17 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Triggered when switching to another scene collection
         /// </summary>
-        public event CurrentSceneCollectionChangedCallback CurrentSceneCollectionChanged;
+        public event EventHandler<CurrentSceneCollectionChangedEventArgs> CurrentSceneCollectionChanged;
 
         /// <summary>
         /// Triggered when a scene collection is created, deleted or renamed
         /// </summary>
-        public event SceneCollectionListChangedCallback SceneCollectionListChanged;
+        public event EventHandler<SceneCollectionListChangedEventArgs> SceneCollectionListChanged;
 
         /// <summary>
         /// Triggered when switching to another transition
         /// </summary>
-        public event CurrentSceneTransitionChangedCallback CurrentSceneTransitionChanged;
+        public event EventHandler<CurrentSceneTransitionChangedEventArgs> CurrentSceneTransitionChanged;
 
         /// <summary>
         /// Triggered when the current transition duration is changed
@@ -733,15 +708,15 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(CurrentSceneCollectionChanged):
-                    CurrentSceneCollectionChanged?.Invoke(this, (string)body["sceneCollectionName"]);
+                    CurrentSceneCollectionChanged?.Invoke(this, new CurrentSceneCollectionChangedEventArgs((string)body["sceneCollectionName"]));
                     break;
 
                 case nameof(SceneCollectionListChanged):
-                    SceneCollectionListChanged?.Invoke(this, JsonConvert.DeserializeObject<List<string>>((string)body["sceneCollections"]));
+                    SceneCollectionListChanged?.Invoke(this, new SceneCollectionListChangedEventArgs(JsonConvert.DeserializeObject<List<string>>((string)body["sceneCollections"])));
                     break;
 
                 case nameof(CurrentSceneTransitionChanged):
-                    CurrentSceneTransitionChanged?.Invoke(this, (string)body["transitionName"]);
+                    CurrentSceneTransitionChanged?.Invoke(this, new CurrentSceneTransitionChangedEventArgs((string)body["transitionName"]));
                     break;
 
                 case nameof(CurrentSceneTransitionDurationChanged):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -10,72 +10,6 @@ using OBSWebsocketDotNet.Types.Events;
 namespace OBSWebsocketDotNet
 {
     #region EventDelegates
-    
-    /// <summary>
-    /// An input's active state has changed.
-    /// When an input is active, it means it's being shown by the program feed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="videoActive">Whether the input is active</param>
-    public delegate void InputActiveStateChangedCallback(OBSWebsocket sender, string inputName, bool videoActive);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputShowStateChanged"/>
-    /// An input's show state has changed.
-    /// When an input is showing, it means it's being shown by the preview or a dialog.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="videoShowing">Whether the input is showing</param>
-    public delegate void InputShowStateChangedCallback(OBSWebsocket sender, string inputName, bool videoShowing);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputAudioBalanceChanged"/>
-    /// The audio balance value of an input has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the affected input</param>
-    /// <param name="inputAudioBalance">New audio balance value of the input</param>
-    public delegate void InputAudioBalanceChangedCallback(OBSWebsocket sender, string inputName, double inputAudioBalance);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputAudioTracksChanged"/>
-    /// The audio tracks of an input have changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="inputAudioTracks">Object of audio tracks along with their associated enable states</param>
-    public delegate void InputAudioTracksChangedCallback(OBSWebsocket sender, string inputName, JObject inputAudioTracks);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputAudioMonitorTypeChanged"/>
-    /// The monitor type of an input has changed.
-    /// Available types are:
-    /// - `OBS_MONITORING_TYPE_NONE`
-    /// - `OBS_MONITORING_TYPE_MONITOR_ONLY`
-    /// - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="monitorType">New monitor type of the input</param>
-    public delegate void InputAudioMonitorTypeChangedCallback(OBSWebsocket sender, string inputName, string monitorType);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputVolumeMeters"/>
-    /// A high-volume event providing volume levels of all active inputs every 50 milliseconds.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputs">Array of active inputs with their associated volume levels</param>
-    public delegate void InputVolumeMetersCallback(OBSWebsocket sender, List<JObject> inputs);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.ReplayBufferSaved"/>
-    /// The replay buffer has been saved.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="savedReplayPath">Path of the saved replay file</param>
-    public delegate void ReplayBufferSavedCallback(OBSWebsocket sender, string savedReplayPath);
 
     /// <summary>
     /// Callback by <see cref="OBSWebsocket.SceneCreated"/>
@@ -335,23 +269,23 @@ namespace OBSWebsocketDotNet
         /// An input's active state has changed.
         /// When an input is active, it means it's being shown by the program feed.
         /// </summary>
-        public event InputActiveStateChangedCallback InputActiveStateChanged;
+        public event EventHandler<InputActiveStateChangedEventArgs> InputActiveStateChanged;
 
         /// <summary>
         /// An input's show state has changed.
         /// When an input is showing, it means it's being shown by the preview or a dialog.
         /// </summary>
-        public event InputShowStateChangedCallback InputShowStateChanged;
+        public event EventHandler<InputShowStateChangedEventArgs> InputShowStateChanged;
 
         /// <summary>
         /// The audio balance value of an input has changed.
         /// </summary>
-        public event InputAudioBalanceChangedCallback InputAudioBalanceChanged;
+        public event EventHandler<InputAudioBalanceChangedEventArgs> InputAudioBalanceChanged;
 
         /// <summary>
         /// The audio tracks of an input have changed.
         /// </summary>
-        public event InputAudioTracksChangedCallback InputAudioTracksChanged;
+        public event EventHandler<InputAudioTracksChangedEventArgs> InputAudioTracksChanged;
 
         /// <summary>
         /// The monitor type of an input has changed.
@@ -360,17 +294,17 @@ namespace OBSWebsocketDotNet
         /// - `OBS_MONITORING_TYPE_MONITOR_ONLY`
         /// - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
         /// </summary>
-        public event InputAudioMonitorTypeChangedCallback InputAudioMonitorTypeChanged;
+        public event EventHandler<InputAudioMonitorTypeChangedEventArgs> InputAudioMonitorTypeChanged;
 
         /// <summary>
         /// A high-volume event providing volume levels of all active inputs every 50 milliseconds.
         /// </summary>
-        public event InputVolumeMetersCallback InputVolumeMeters;
+        public event EventHandler<InputVolumeMetersEventArgs> InputVolumeMeters;
 
         /// <summary>
         /// The replay buffer has been saved.
         /// </summary>
-        public event ReplayBufferSavedCallback ReplayBufferSaved;
+        public event EventHandler<ReplayBufferSavedEventArgs> ReplayBufferSaved;
 
         /// <summary>
         /// A new scene has been created.
@@ -577,31 +511,31 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(InputActiveStateChanged):
-                    InputActiveStateChanged?.Invoke(this, (string)body["inputName"], (bool)body["videoActive"]);
+                    InputActiveStateChanged?.Invoke(this, new InputActiveStateChangedEventArgs((string)body["inputName"], (bool)body["videoActive"]));
                     break;
 
                 case nameof(InputShowStateChanged):
-                    InputShowStateChanged?.Invoke(this, (string)body["inputName"], (bool)body["videoShowing"]);
+                    InputShowStateChanged?.Invoke(this, new InputShowStateChangedEventArgs((string)body["inputName"], (bool)body["videoShowing"]));
                     break;
 
                 case nameof(InputAudioBalanceChanged):
-                    InputAudioBalanceChanged?.Invoke(this, (string)body["inputName"], (double)body["inputAudioBalance"]);
+                    InputAudioBalanceChanged?.Invoke(this, new InputAudioBalanceChangedEventArgs((string)body["inputName"], (double)body["inputAudioBalance"]));
                     break;
 
                 case nameof(InputAudioTracksChanged):
-                    InputAudioTracksChanged?.Invoke(this, (string)body["inputName"], (JObject)body["inputAudioTracks"]);
+                    InputAudioTracksChanged?.Invoke(this, new InputAudioTracksChangedEventArgs((string)body["inputName"], (JObject)body["inputAudioTracks"]));
                     break;
 
                 case nameof(InputAudioMonitorTypeChanged):
-                    InputAudioMonitorTypeChanged?.Invoke(this, (string)body["inputName"], (string)body["monitorType"]);
+                    InputAudioMonitorTypeChanged?.Invoke(this, new InputAudioMonitorTypeChangedEventArgs((string)body["inputName"], (string)body["monitorType"]));
                     break;
 
                 case nameof(InputVolumeMeters):
-                    InputVolumeMeters?.Invoke(this, JsonConvert.DeserializeObject<List<JObject>>((string)body["inputs"]));
+                    InputVolumeMeters?.Invoke(this, new InputVolumeMetersEventArgs(JsonConvert.DeserializeObject<List<JObject>>((string)body["inputs"])));
                     break;
 
                 case nameof(ReplayBufferSaved):
-                    ReplayBufferSaved?.Invoke(this, (string)body["savedReplayPath"]);
+                    ReplayBufferSaved?.Invoke(this, new ReplayBufferSavedEventArgs((string)body["savedReplayPath"]));
                     break;
 
                 case nameof(SceneCreated):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -12,63 +12,6 @@ namespace OBSWebsocketDotNet
     #region EventDelegates
     
     /// <summary>
-    /// Callback by <see cref="OBSWebsocket.CurrentSceneCollectionChanging"/>
-    /// The current scene collection has begun changing.
-    /// Note: We recommend using this event to trigger a pause of all polling requests, as performing any requests during a
-    /// scene collection change is considered undefined behavior and can cause crashes!
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneCollectionName">Name of the current scene collection</param>
-    public delegate void CurrentSceneCollectionChangingCallback(OBSWebsocket sender, string sceneCollectionName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.CurrentProfileChanging"/>
-    /// The current profile has begun changing.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="profileName">Name of the current profile</param>
-    public delegate void CurrentProfileChangingCallback(OBSWebsocket sender, string profileName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SourceFilterNameChanged"/>
-    /// The name of a source filter has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sourceName">The source the filter is on</param>
-    /// <param name="oldFilterName">Old name of the filter</param>
-    /// <param name="filterName">New name of the filter</param>
-    public delegate void SourceFilterNameChangedCallback(OBSWebsocket sender, string sourceName, string oldFilterName, string filterName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputCreated"/>
-    /// An input has been created.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">ame of the input</param>
-    /// <param name="inputKind">The kind of the input</param>
-    /// <param name="unversionedInputKind">The unversioned kind of input (aka no `_v2` stuff)</param>
-    /// <param name="inputSettings">The settings configured to the input when it was created</param>
-    /// <param name="defaultInputSettings">The default settings for the input</param>
-    public delegate void InputCreatedCallback(OBSWebsocket sender, string inputName, string inputKind, string unversionedInputKind, JObject inputSettings, JObject defaultInputSettings);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputRemoved"/>
-    /// An input has been removed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    public delegate void InputRemovedCallback(OBSWebsocket sender, string inputName);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputNameChanged"/>
-    /// The name of an input has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="oldInputName">Old name of the input</param>
-    /// <param name="inputName">New name of the input</param>
-    public delegate void InputNameChangedCallback(OBSWebsocket sender, string oldInputName, string inputName);
-
-    /// <summary>
     /// An input's active state has changed.
     /// When an input is active, it means it's being shown by the program feed.
     /// </summary>
@@ -361,32 +304,32 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// The current scene collection has begun changing.
         /// </summary>
-        public event CurrentSceneCollectionChangingCallback CurrentSceneCollectionChanging;
+        public event EventHandler<CurrentSceneCollectionChangingEventArgs> CurrentSceneCollectionChanging;
 
         /// <summary>
         /// The current profile has begun changing.
         /// </summary>
-        public event CurrentProfileChangingCallback CurrentProfileChanging;
+        public event EventHandler<CurrentProfileChangingEventArgs> CurrentProfileChanging;
 
         /// <summary>
         /// The name of a source filter has changed.
         /// </summary>
-        public event SourceFilterNameChangedCallback SourceFilterNameChanged;
+        public event EventHandler<SourceFilterNameChangedEventArgs> SourceFilterNameChanged;
 
         /// <summary>
         /// An input has been created.
         /// </summary>
-        public event InputCreatedCallback InputCreated;
+        public event EventHandler<InputCreatedEventArgs> InputCreated;
 
         /// <summary>
         /// An input has been removed.
         /// </summary>
-        public event InputRemovedCallback InputRemoved;
+        public event EventHandler<InputRemovedEventArgs> InputRemoved;
 
         /// <summary>
         /// The name of an input has changed.
         /// </summary>
-        public event InputNameChangedCallback InputNameChanged;
+        public event EventHandler<InputNameChangedEventArgs> InputNameChanged;
 
         /// <summary>
         /// An input's active state has changed.
@@ -610,27 +553,27 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(CurrentSceneCollectionChanging):
-                    CurrentSceneCollectionChanging?.Invoke(this, (string)body["sceneCollectionName"]);
+                    CurrentSceneCollectionChanging?.Invoke(this, new CurrentSceneCollectionChangingEventArgs((string)body["sceneCollectionName"]));
                     break;
 
                 case nameof(CurrentProfileChanging):
-                    CurrentProfileChanging?.Invoke(this, (string)body["profileName"]);
+                    CurrentProfileChanging?.Invoke(this, new CurrentProfileChangingEventArgs((string)body["profileName"]));
                     break;
 
                 case nameof(SourceFilterNameChanged):
-                    SourceFilterNameChanged?.Invoke(this, (string)body["sourceName"], (string)body["oldFilterName"], (string)body["filterName"]);
+                    SourceFilterNameChanged?.Invoke(this, new SourceFilterNameChangedEventArgs((string)body["sourceName"], (string)body["oldFilterName"], (string)body["filterName"]));
                     break;
 
                 case nameof(InputCreated):
-                    InputCreated?.Invoke(this, (string)body["inputName"], (string)body["inputKind"], (string)body["unversionedInputKind"], (JObject)body["inputSettings"], (JObject)body["defaultInputSettings"]);
+                    InputCreated?.Invoke(this, new InputCreatedEventArgs((string)body["inputName"], (string)body["inputKind"], (string)body["unversionedInputKind"], (JObject)body["inputSettings"], (JObject)body["defaultInputSettings"]));
                     break;
 
                 case nameof(InputRemoved):
-                    InputRemoved?.Invoke(this, (string)body["inputName"]);
+                    InputRemoved?.Invoke(this, new InputRemovedEventArgs((string)body["inputName"]));
                     break;
 
                 case nameof(InputNameChanged):
-                    InputNameChanged?.Invoke(this, (string)body["oldInputName"], (string)body["inputName"]);
+                    InputNameChanged?.Invoke(this, new InputNameChangedEventArgs((string)body["oldInputName"], (string)body["inputName"]));
                     break;
 
                 case nameof(InputActiveStateChanged):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -10,31 +10,7 @@ using OBSWebsocketDotNet.Types.Events;
 namespace OBSWebsocketDotNet
 {
     #region EventDelegates
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.ProfileListChanged"/>
-    /// The profile list has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="profiles">Updated list of profiles</param>
-    public delegate void ProfileListChangedCallback(OBSWebsocket sender, List<string> profiles);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.StreamStateChanged"/>
-    /// The state of the stream output has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="outputState">The specific state of the output</param>
-    public delegate void StreamStateChangedCallback(OBSWebsocket sender, OutputStateChanged outputState);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.RecordStateChanged"/>
-    /// The state of the record output has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="outputState">The specific state of the output</param>
-    public delegate void RecordStateChangedCallback(OBSWebsocket sender, RecordStateChanged outputState);
-
+    
     /// <summary>
     /// Called by <see cref="OBSWebsocket.CurrentPreviewSceneChanged"/>
     /// The current preview scene has changed.
@@ -422,17 +398,17 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Triggered when a profile is created, imported, removed or renamed
         /// </summary>
-        public event ProfileListChangedCallback ProfileListChanged;
+        public event EventHandler<ProfileListChangedEventArgs> ProfileListChanged;
 
         /// <summary>
         /// Triggered when the streaming output state changes
         /// </summary>
-        public event StreamStateChangedCallback StreamStateChanged;
+        public event EventHandler<StreamStateChangedEventArgs> StreamStateChanged;
 
         /// <summary>
         /// Triggered when the recording output state changes
         /// </summary>
-        public event RecordStateChangedCallback RecordStateChanged;
+        public event EventHandler<RecordStateChangedEventArgs> RecordStateChanged;
 
         /// <summary>
         /// Triggered when state of the replay buffer changes
@@ -696,15 +672,15 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(ProfileListChanged):
-                    ProfileListChanged?.Invoke(this, JsonConvert.DeserializeObject<List<string>>((string)body["profiles"]));
+                    ProfileListChanged?.Invoke(this, new ProfileListChangedEventArgs(JsonConvert.DeserializeObject<List<string>>((string)body["profiles"])));
                     break;
 
                 case nameof(StreamStateChanged):
-                    StreamStateChanged?.Invoke(this, new OutputStateChanged(body));
+                    StreamStateChanged?.Invoke(this, new StreamStateChangedEventArgs(new OutputStateChanged(body)));
                     break;
 
                 case nameof(RecordStateChanged):
-                    RecordStateChanged?.Invoke(this, new RecordStateChanged(body));
+                    RecordStateChanged?.Invoke(this, new RecordStateChangedEventArgs(new RecordStateChanged(body)));
                     break;
 
                 case nameof(CurrentPreviewSceneChanged):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -10,73 +10,6 @@ using OBSWebsocketDotNet.Types.Events;
 namespace OBSWebsocketDotNet
 {
     #region EventDelegates
-    
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.CurrentPreviewSceneChanged"/>
-    /// The current preview scene has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene that was switched to</param>
-    public delegate void CurrentPreviewSceneChangedCallback(OBSWebsocket sender, string sceneName);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.StudioModeStateChanged"/>
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="studioModeEnabled">New Studio Mode status</param>
-    public delegate void StudioModeStateChangedCallback(OBSWebsocket sender, bool studioModeEnabled);
-
-    /// <summary>
-    /// Called by <see cref="OBSWebsocket.ReplayBufferStateChanged"/>
-    /// The state of the replay buffer output has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="outputState">The specific state of the output</param>
-    public delegate void ReplayBufferStateChangedCallback(OBSWebsocket sender, OutputStateChanged outputState);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SceneItemSelected"/>
-    /// A scene item has been selected in the Ui.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the scene item is in</param>
-    /// <param name="sceneItemId">Numeric ID of the scene item</param>
-    public delegate void SceneItemSelectedCallback(OBSWebsocket sender, string sceneName, string sceneItemId);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SceneItemTransformChanged"/>
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// /// <param name="sceneName">Name of the scene item is in</param>
-    /// <param name="sceneItemId">Numeric ID of the scene item</param>
-    /// <param name="transform">Transform data</param>
-    public delegate void SceneItemTransformCallback(OBSWebsocket sender, string sceneName, string sceneItemId, SceneItemTransformInfo transform);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputAudioSyncOffsetChanged"/>
-    /// The sync offset of an input has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="inputAudioSyncOffset">New sync offset in milliseconds</param>
-    public delegate void InputAudioSyncOffsetChangedCallback(OBSWebsocket sender, string inputName, int inputAudioSyncOffset);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputMuteStateChanged"/>
-    /// An input's mute state has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="inputName">Name of the input</param>
-    /// <param name="inputMuted">Whether the input is muted</param>
-    public delegate void InputMuteStateChangedCallback(OBSWebsocket sender, string inputName, bool inputMuted);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.InputVolumeChanged"/>
-    /// An input's volume level has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="volume">Current volume levels of source</param>
-    public delegate void InputVolumeChangedCallback(OBSWebsocket sender, InputVolume volume);
 
     /// <summary>
     /// Callback by <see cref="OBSWebsocket.SourceFilterRemoved"/>
@@ -413,17 +346,17 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// Triggered when state of the replay buffer changes
         /// </summary>
-        public event ReplayBufferStateChangedCallback ReplayBufferStateChanged;
+        public event EventHandler<ReplayBufferStateChangedEventArgs> ReplayBufferStateChanged;
 
         /// <summary>
         /// Triggered when the preview scene selection changes (Studio Mode only)
         /// </summary>
-        public event CurrentPreviewSceneChangedCallback CurrentPreviewSceneChanged;
+        public event EventHandler<CurrentPreviewSceneChangedEventArgs> CurrentPreviewSceneChanged;
 
         /// <summary>
         /// Triggered when Studio Mode is turned on or off
         /// </summary>
-        public event StudioModeStateChangedCallback StudioModeStateChanged;
+        public event EventHandler<StudioModeStateChangedEventArgs> StudioModeStateChanged;
 
         /// <summary>
         /// Triggered when OBS exits
@@ -443,17 +376,17 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// A scene item is selected in the UI
         /// </summary>
-        public event SceneItemSelectedCallback SceneItemSelected;
+        public event EventHandler<SceneItemSelectedEventArgs> SceneItemSelected;
 
         /// <summary>
         /// A scene item transform has changed
         /// </summary>
-        public event SceneItemTransformCallback SceneItemTransformChanged;
+        public event EventHandler<SceneItemTransformEventArgs> SceneItemTransformChanged;
 
         /// <summary>
         /// The audio sync offset of an input has changed
         /// </summary>
-        public event InputAudioSyncOffsetChangedCallback InputAudioSyncOffsetChanged;
+        public event EventHandler<InputAudioSyncOffsetChangedEventArgs> InputAudioSyncOffsetChanged;
 
         /// <summary>
         /// A filter was added to a source
@@ -478,12 +411,12 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// A source has been muted or unmuted
         /// </summary>
-        public event InputMuteStateChangedCallback InputMuteStateChanged;
+        public event EventHandler<InputMuteStateChangedEventArgs> InputMuteStateChanged;
 
         /// <summary>
         /// The volume of a source has changed
         /// </summary>
-        public event InputVolumeChangedCallback InputVolumeChanged;
+        public event EventHandler<InputVolumeChangedEventArgs> InputVolumeChanged;
 
         /// <summary>
         /// A custom broadcast message was received
@@ -684,15 +617,15 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(CurrentPreviewSceneChanged):
-                    CurrentPreviewSceneChanged?.Invoke(this, (string)body["sceneName"]);
+                    CurrentPreviewSceneChanged?.Invoke(this, new CurrentPreviewSceneChangedEventArgs((string)body["sceneName"]));
                     break;
 
                 case nameof(StudioModeStateChanged):
-                    StudioModeStateChanged?.Invoke(this, (bool)body["studioModeEnabled"]);
+                    StudioModeStateChanged?.Invoke(this, new StudioModeStateChangedEventArgs((bool)body["studioModeEnabled"]));
                     break;
 
                 case nameof(ReplayBufferStateChanged):
-                    ReplayBufferStateChanged?.Invoke(this, new OutputStateChanged(body));
+                    ReplayBufferStateChanged?.Invoke(this, new ReplayBufferStateChangedEventArgs(new OutputStateChanged(body)));
                     break;
 
                 case nameof(ExitStarted):
@@ -700,23 +633,23 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(SceneItemSelected):
-                    SceneItemSelected?.Invoke(this, (string)body["sceneName"], (string)body["sceneItemId"]);
+                    SceneItemSelected?.Invoke(this, new SceneItemSelectedEventArgs((string)body["sceneName"], (string)body["sceneItemId"]));
                     break;
 
                 case nameof(SceneItemTransformChanged):
-                    SceneItemTransformChanged?.Invoke(this, (string)body["sceneName"], (string)body["sceneItemId"], new SceneItemTransformInfo((JObject)body["sceneItemTransform"]));
+                    SceneItemTransformChanged?.Invoke(this, new SceneItemTransformEventArgs((string)body["sceneName"], (string)body["sceneItemId"], new SceneItemTransformInfo((JObject)body["sceneItemTransform"])));
                     break;
 
                 case nameof(InputAudioSyncOffsetChanged):
-                    InputAudioSyncOffsetChanged?.Invoke(this, (string)body["inputName"], (int)body["inputAudioSyncOffset"]);
+                    InputAudioSyncOffsetChanged?.Invoke(this, new InputAudioSyncOffsetChangedEventArgs((string)body["inputName"], (int)body["inputAudioSyncOffset"]));
                     break;
 
                 case nameof(InputMuteStateChanged):
-                    InputMuteStateChanged?.Invoke(this, (string)body["inputName"], (bool)body["inputMuted"]);
+                    InputMuteStateChanged?.Invoke(this, new InputMuteStateChangedEventArgs((string)body["inputName"], (bool)body["inputMuted"]));
                     break;
 
                 case nameof(InputVolumeChanged):
-                    InputVolumeChanged?.Invoke(this, new InputVolume(body));
+                    InputVolumeChanged?.Invoke(this, new InputVolumeChangedEventArgs(new InputVolume(body)));
                     break;
 
                 case nameof(SourceFilterCreated):

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -9,37 +9,6 @@ using OBSWebsocketDotNet.Types.Events;
 
 namespace OBSWebsocketDotNet
 {
-    #region EventDelegates
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SceneCreated"/>
-    /// A new scene has been created.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the new scene</param>
-    /// <param name="isGroup">Whether the new scene is a group</param>
-    public delegate void SceneCreatedCallback(OBSWebsocket sender, string sceneName, bool isGroup);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SceneRemoved"/>
-    /// A scene has been removed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="sceneName">Name of the removed scene</param>
-    /// <param name="isGroup">Whether the scene was a group</param>
-    public delegate void SceneRemovedCallback(OBSWebsocket sender, string sceneName, bool isGroup);
-
-    /// <summary>
-    /// Callback by <see cref="OBSWebsocket.SceneNameChanged"/>
-    /// The name of a scene has changed.
-    /// </summary>
-    /// <param name="sender"><see cref="OBSWebsocket"/> instance</param>
-    /// <param name="oldSceneName">Old name of the scene</param>
-    /// <param name="sceneName">New name of the scene</param>
-    public delegate void SceneNameChangedCallback(OBSWebsocket sender, string oldSceneName, string sceneName);
-
-    #endregion
-
     public partial class OBSWebsocket
     {
         #region Events
@@ -309,17 +278,17 @@ namespace OBSWebsocketDotNet
         /// <summary>
         /// A new scene has been created.
         /// </summary>
-        public event SceneCreatedCallback SceneCreated;
+        public event EventHandler<SceneCreatedEventArgs> SceneCreated;
 
         /// <summary>
         /// A scene has been removed.
         /// </summary>
-        public event SceneRemovedCallback SceneRemoved;
+        public event EventHandler<SceneRemovedEventArgs> SceneRemoved;
 
         /// <summary>
         /// The name of a scene has changed.
         /// </summary>
-        public event SceneNameChangedCallback SceneNameChanged;
+        public event EventHandler<SceneNameChangedEventArgs> SceneNameChanged;
 
         #endregion
 
@@ -539,15 +508,15 @@ namespace OBSWebsocketDotNet
                     break;
 
                 case nameof(SceneCreated):
-                    SceneCreated?.Invoke(this, (string)body["sceneName"], (bool)body["isGroup"]);
+                    SceneCreated?.Invoke(this, new SceneCreatedEventArgs((string)body["sceneName"], (bool)body["isGroup"]));
                     break;
 
                 case nameof(SceneRemoved):
-                    SceneRemoved?.Invoke(this, (string)body["sceneName"], (bool)body["isGroup"]);
+                    SceneRemoved?.Invoke(this, new SceneRemovedEventArgs((string)body["sceneName"], (bool)body["isGroup"]));
                     break;
 
                 case nameof(SceneNameChanged):
-                    SceneNameChanged?.Invoke(this, (string)body["oldSceneName"], (string)body["sceneName"]);
+                    SceneNameChanged?.Invoke(this, new SceneNameChangedEventArgs((string)body["oldSceneName"], (string)body["sceneName"]));
                     break;
 
                 default:

--- a/obs-websocket-dotnet/Types/Events/CurrentPreviewSceneChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentPreviewSceneChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentPreviewSceneChanged"/>
+    /// </summary>
+    public class CurrentPreviewSceneChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the scene that was switched to
+        /// </summary>
+        public string SceneName { get; }
+
+        public CurrentPreviewSceneChangedEventArgs(string sceneName)
+        {
+            SceneName = sceneName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/CurrentProfileChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentProfileChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentProfileChanged"/>
+    /// </summary>
+    public class CurrentProfileChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the new profile
+        /// </summary>
+        public string ProfileName { get; }
+
+        public CurrentProfileChangedEventArgs(string profileName)
+        {
+            ProfileName = profileName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/CurrentProfileChangingEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentProfileChangingEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentProfileChanging"/>
+    /// </summary>
+    public class CurrentProfileChangingEventArgs
+    {
+        /// <summary>
+        /// Name of the current profile
+        /// </summary>
+        public string ProfileName { get; }
+
+        public CurrentProfileChangingEventArgs(string profileName)
+        {
+            ProfileName = profileName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/CurrentSceneCollectionChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentSceneCollectionChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentSceneCollectionChanged"/> 
+    /// </summary>
+    public class CurrentSceneCollectionChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the new scene collection
+        /// </summary>
+        public string SceneCollectionName { get; }
+
+        public CurrentSceneCollectionChangedEventArgs(string sceneCollectionName)
+        {
+            SceneCollectionName = sceneCollectionName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/CurrentSceneCollectionChangingEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentSceneCollectionChangingEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentSceneCollectionChanging"/>
+    /// </summary>
+    public class CurrentSceneCollectionChangingEventArgs
+    {
+        /// <summary>
+        /// Name of the current scene collection
+        /// </summary>
+        public string SceneCollectionName { get; }
+
+        public CurrentSceneCollectionChangingEventArgs(string sceneCollectionName)
+        {
+            SceneCollectionName = sceneCollectionName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/CurrentSceneTransitionChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentSceneTransitionChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentSceneTransitionChanged"/>
+    /// </summary>
+    public class CurrentSceneTransitionChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the new transition
+        /// </summary>
+        public string TransitionName { get; }
+
+        public CurrentSceneTransitionChangedEventArgs(string transitionName)
+        {
+            TransitionName = transitionName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/CurrentSceneTransitionDurationChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/CurrentSceneTransitionDurationChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentSceneTransitionDurationChanged"/>
+    /// </summary>
+    public class CurrentSceneTransitionDurationChangedEventArgs
+    {
+        /// <summary>
+        /// Transition duration in milliseconds
+        /// </summary>
+        public int TransitionDuration { get; }
+
+        public CurrentSceneTransitionDurationChangedEventArgs(int transitionDuration)
+        {
+            TransitionDuration = transitionDuration;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputActiveStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputActiveStateChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputActiveStateChanged"/>
+    /// </summary>
+    public class InputActiveStateChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// Whether the input is active
+        /// </summary>
+        public bool VideoActive { get; }
+
+        public InputActiveStateChangedEventArgs(string inputName, bool videoActive)
+        {
+            InputName = inputName;
+            VideoActive = videoActive;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputAudioBalanceChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputAudioBalanceChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputAudioBalanceChanged"/>
+    /// </summary>
+    public class InputAudioBalanceChangedEventArgs
+    {   
+        /// <summary>
+        /// Name of the affected input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// New audio balance value of the input
+        /// </summary>
+        public double InputAudioBalance { get; }
+
+        public InputAudioBalanceChangedEventArgs(string inputName, double inputAudioBalance)
+        {
+            InputName = inputName;
+            InputAudioBalance = inputAudioBalance;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputAudioMonitorTypeChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputAudioMonitorTypeChangedEventArgs.cs
@@ -1,0 +1,28 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputAudioMonitorTypeChanged"/>
+    /// Available types are:
+    /// - `OBS_MONITORING_TYPE_NONE`
+    /// - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+    /// - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
+    /// </summary>
+    public class InputAudioMonitorTypeChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// New monitor type of the input
+        /// </summary>
+        public string MonitorType { get; }
+
+        public InputAudioMonitorTypeChangedEventArgs(string inputName, string monitorType)
+        {
+            InputName = inputName;
+            MonitorType = monitorType;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputAudioSyncOffsetChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputAudioSyncOffsetChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputAudioSyncOffsetChanged"/>
+    /// </summary>
+    public class InputAudioSyncOffsetChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// New sync offset in milliseconds
+        /// </summary>
+        public int InputAudioSyncOffset { get; }
+
+        public InputAudioSyncOffsetChangedEventArgs(string inputName, int inputAudioSyncOffset)
+        {
+            InputName = inputName;
+            InputAudioSyncOffset = inputAudioSyncOffset;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputAudioTracksChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputAudioTracksChangedEventArgs.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputAudioTracksChanged"/>
+    /// </summary>
+    public class InputAudioTracksChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// Object of audio tracks along with their associated enable states
+        /// </summary>
+        public JObject InputAudioTracks {get;}
+
+        public InputAudioTracksChangedEventArgs(string inputName, JObject inputAudioTracks)
+        {
+            InputName = inputName;
+            InputAudioTracks = inputAudioTracks;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputCreatedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputCreatedEventArgs.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputCreated"/>
+    /// </summary>
+    public class InputCreatedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; } 
+        
+        /// <summary>
+        /// The kind of the input
+        /// </summary>
+        public string InputKind { get; }
+        
+        /// <summary>
+        /// The unversioned kind of input (aka no `_v2` stuff)
+        /// </summary>
+        public string UnversionedInputKind { get; } 
+        
+        /// <summary>
+        /// The settings configured to the input when it was created
+        /// </summary>
+        public JObject InputSettings { get; } 
+        
+        /// <summary>
+        /// The default settings for the input
+        /// </summary>
+        public JObject DefaultInputSettings { get; }
+
+        public InputCreatedEventArgs(string inputName, string inputKind, string unversionedInputKind, JObject inputSettings, JObject defaultInputSettings)
+        {
+            InputName = inputName;
+            InputKind = inputKind;
+            UnversionedInputKind = unversionedInputKind;
+            InputSettings = inputSettings;
+            DefaultInputSettings = defaultInputSettings;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputMuteStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputMuteStateChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputMuteStateChanged"/>
+    /// </summary>
+    public class InputMuteStateChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// Whether the input is muted
+        /// </summary>
+        public bool InputMuted { get; }
+
+        public InputMuteStateChangedEventArgs(string inputName, bool inputMuted)
+        {
+            InputName = inputName;
+            InputMuted = inputMuted;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputNameChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputNameChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputNameChanged"/>
+    /// </summary>
+    public class InputNameChangedEventArgs
+    {
+        /// <summary>
+        /// Old name of the input
+        /// </summary>
+        public string OldInputName { get; }
+        
+        /// <summary>
+        /// New name of the input
+        /// </summary>
+        public string InputName { get; }
+
+        public InputNameChangedEventArgs(string oldInputName, string inputName)
+        {
+            OldInputName = oldInputName;
+            InputName = inputName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputRemovedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputRemovedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputRemoved"/>
+    /// </summary>
+    public class InputRemovedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+
+        public InputRemovedEventArgs(string inputName)
+        {
+            InputName = inputName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputShowStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputShowStateChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputShowStateChanged"/>
+    /// </summary>
+    public class InputShowStateChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+        
+        /// <summary>
+        /// Whether the input is showing
+        /// </summary>
+        public bool VideoShowing { get; }
+
+        public InputShowStateChangedEventArgs(string inputName, bool videoShowing)
+        {
+            InputName = inputName;
+            VideoShowing = videoShowing;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputVolumeChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputVolumeChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputVolumeChanged"/>
+    /// </summary>
+    public class InputVolumeChangedEventArgs
+    {
+        /// <summary>
+        /// Current volume levels of source
+        /// </summary>
+        public InputVolume Volume { get; }
+
+        public InputVolumeChangedEventArgs(InputVolume volume)
+        {
+            Volume = volume;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/InputVolumeMetersEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/InputVolumeMetersEventArgs.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.InputVolumeMeters"/>
+    /// </summary>
+    public class InputVolumeMetersEventArgs
+    {
+        /// <summary>
+        /// Array of active inputs with their associated volume levels
+        /// </summary>
+        public List<JObject> inputs { get; }
+
+        public InputVolumeMetersEventArgs(List<JObject> inputs)
+        {
+            this.inputs = inputs;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/MediaInputActionTriggeredEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/MediaInputActionTriggeredEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.MediaInputActionTriggered"/>
+    /// </summary>
+    public class MediaInputActionTriggeredEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; } 
+        
+        /// <summary>
+        /// Action performed on the input. See `ObsMediaInputAction` enum
+        /// </summary>
+        public string MediaAction { get; }
+
+        public MediaInputActionTriggeredEventArgs(string inputName, string mediaAction)
+        {
+            InputName = inputName;
+            MediaAction = mediaAction;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/MediaInputPlaybackEndedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/MediaInputPlaybackEndedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.MediaInputPlaybackEnded"/>
+    /// </summary>
+    public class MediaInputPlaybackEndedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+
+        public MediaInputPlaybackEndedEventArgs(string inputName)
+        {
+            InputName = inputName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/MediaInputPlaybackStartedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/MediaInputPlaybackStartedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.MediaInputPlaybackStarted"/>
+    /// </summary>
+    public class MediaInputPlaybackStartedEventArgs
+    {
+        /// <summary>
+        /// Name of the input
+        /// </summary>
+        public string InputName { get; }
+
+        public MediaInputPlaybackStartedEventArgs(string inputName)
+        {
+            InputName = inputName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/ProfileListChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/ProfileListChangedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.ProfileListChanged"/>
+    /// </summary>
+    public class ProfileListChangedEventArgs
+    {
+        public List<string> Profiles { get; }
+
+        public ProfileListChangedEventArgs(List<string> profiles)
+        {
+            Profiles = profiles;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/ProgramSceneChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/ProgramSceneChangedEventArgs.cs
@@ -1,0 +1,15 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.CurrentProgramSceneChanged"/>
+    /// </summary>
+    public class ProgramSceneChangedEventArgs
+    {
+        public string SceneName { get; }
+
+        public ProgramSceneChangedEventArgs(string sceneName)
+        {
+            SceneName = sceneName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/ProgramSceneChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/ProgramSceneChangedEventArgs.cs
@@ -5,6 +5,9 @@
     /// </summary>
     public class ProgramSceneChangedEventArgs
     {
+        /// <summary>
+        /// The new scene name
+        /// </summary>
         public string SceneName { get; }
 
         public ProgramSceneChangedEventArgs(string sceneName)

--- a/obs-websocket-dotnet/Types/Events/RecordStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/RecordStateChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.RecordStateChanged"/>
+    /// </summary>
+    public class RecordStateChangedEventArgs
+    {
+        /// <summary>
+        /// The specific state of the output
+        /// </summary>
+        public RecordStateChanged OutputState { get; }
+
+        public RecordStateChangedEventArgs(RecordStateChanged outputState)
+        {
+            OutputState = outputState;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/ReplayBufferSavedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/ReplayBufferSavedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.ReplayBufferSaved"/>
+    /// </summary>
+    public class ReplayBufferSavedEventArgs
+    {
+        /// <summary>
+        /// Path of the saved replay file
+        /// </summary>
+        public string SavedReplayPath { get; }
+
+        public ReplayBufferSavedEventArgs(string savedReplayPath)
+        {
+            SavedReplayPath = savedReplayPath;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/ReplayBufferStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/ReplayBufferStateChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.ReplayBufferStateChanged"/>
+    /// </summary>
+    public class ReplayBufferStateChangedEventArgs
+    {
+        /// <summary>
+        /// The specific state of the output
+        /// </summary>
+        public OutputStateChanged OutputState { get; }
+
+        public ReplayBufferStateChangedEventArgs(OutputStateChanged outputState)
+        {
+            OutputState = outputState;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneCollectionListChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneCollectionListChangedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneCollectionListChanged"/>
+    /// </summary>
+    public class SceneCollectionListChangedEventArgs
+    {
+        /// <summary>
+        /// Updated list of scene collections
+        /// </summary>
+        public List<string> SceneCollections { get; }
+
+        public SceneCollectionListChangedEventArgs(List<string> sceneCollections)
+        {
+            SceneCollections = sceneCollections;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneCreatedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneCreatedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneCreated"/>
+    /// </summary>
+    public class SceneCreatedEventArgs
+    {
+        /// <summary>
+        /// Name of the new scene
+        /// </summary>
+        public string SceneName { get; }
+        
+        /// <summary>
+        /// Whether the new scene is a group
+        /// </summary>
+        public bool IsGroup { get; }
+
+        public SceneCreatedEventArgs(string sceneName, bool isGroup)
+        {
+            SceneName = sceneName;
+            IsGroup = isGroup;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemCreatedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemCreatedEventArgs.cs
@@ -1,0 +1,36 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemCreated"/>
+    /// </summary>
+    public class SceneItemCreatedEventArgs
+    {
+        /// <summary>
+        /// Name of the scene where the item is
+        /// </summary>
+        public string SceneName { get; } 
+        
+        /// <summary>
+        /// Name of the concerned item
+        /// </summary>
+        public string SourceName { get; }
+        
+        /// <summary>
+        /// Numeric ID of the scene item
+        /// </summary>
+        public int SceneItemId { get; } 
+        
+        /// <summary>
+        /// Index position of the item
+        /// </summary>
+        public int SceneItemIndex { get; }
+
+        public SceneItemCreatedEventArgs(string sceneName, string sourceName, int sceneItemId, int sceneItemIndex)
+        {
+            SceneName = sceneName;
+            SourceName = sourceName;
+            SceneItemId = sceneItemId;
+            SceneItemIndex = sceneItemIndex;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemEnableStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemEnableStateChangedEventArgs.cs
@@ -1,0 +1,30 @@
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemEnableStateChanged"/>
+    /// </summary>
+    public class SceneItemEnableStateChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the scene the item is in
+        /// </summary>
+        public string SceneName { get; } 
+        
+        /// <summary>
+        /// Numeric ID of the scene item
+        /// </summary>
+        public int SceneItemId { get; }
+        
+        /// <summary>
+        /// Whether the scene item is enabled (visible)
+        /// </summary>
+        public bool SceneItemEnabled { get; }
+
+        public SceneItemEnableStateChangedEventArgs(string sceneName, int sceneItemId, bool sceneItemEnabled)
+        {
+            SceneName = sceneName;
+            SceneItemId = sceneItemId;
+            SceneItemEnabled = sceneItemEnabled;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemListReindexedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemListReindexedEventArgs.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemListReindexed"/>
+    /// </summary>
+    public class SceneItemListReindexedEventArgs 
+    {
+        /// <summary>
+        /// Name of the scene where items where reordered
+        /// </summary>
+        public string SceneName { get; } 
+
+        /// <summary>
+        /// List of all scene items as JObject
+        /// </summary>
+        public List<JObject> SceneItems { get; }
+
+        public SceneItemListReindexedEventArgs(string sceneName, List<JObject> sceneItems)
+        {
+            SceneName = sceneName;
+            SceneItems = sceneItems;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemLockStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemLockStateChangedEventArgs.cs
@@ -1,0 +1,30 @@
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemLockStateChanged"/>
+    /// </summary>
+    public class SceneItemLockStateChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the scene the item is in
+        /// </summary>
+        public string SceneName { get; } 
+        
+        /// <summary>
+        /// Numeric ID of the scene item
+        /// </summary>
+        public int SceneItemId { get; }
+        
+        /// <summary>
+        /// Whether the scene item is locked (visible)
+        /// </summary>
+        public bool SceneItemLocked { get; }
+
+        public SceneItemLockStateChangedEventArgs(string sceneName, int sceneItemId, bool sceneItemLocked)
+        {
+            SceneName = sceneName;
+            SceneItemId = sceneItemId;
+            SceneItemLocked = sceneItemLocked;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemRemovedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemRemovedEventArgs.cs
@@ -1,0 +1,31 @@
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemRemoved"/>
+    /// </summary>
+    public class SceneItemRemovedEventArgs
+    {
+        /// <summary>
+        /// Name of the scene where the item was removed from
+        /// </summary>
+        public string SceneName { get; } 
+        
+        /// <summary>
+        /// Name of the concerned item
+        /// </summary>
+        public string SourceName { get; }
+        
+        /// <summary>
+        /// Numeric ID of the scene item
+        /// </summary>
+        public int SceneItemId { get; } 
+
+
+        public SceneItemRemovedEventArgs(string sceneName, string sourceName, int sceneItemId)
+        {
+            SceneName = sceneName;
+            SourceName = sourceName;
+            SceneItemId = sceneItemId;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemSelectedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemSelectedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemSelected"/>
+    /// </summary>
+    public class SceneItemSelectedEventArgs
+    {
+        /// <summary>
+        /// Name of the scene item is in
+        /// </summary>
+        public string SceneName { get; }
+        
+        /// <summary>
+        /// Numeric ID of the scene item
+        /// </summary>
+        public string SceneItemId { get; }
+
+        public SceneItemSelectedEventArgs(string sceneName, string sceneItemId)
+        {
+            SceneName = sceneName;
+            SceneItemId = sceneItemId;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneItemTransformEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneItemTransformEventArgs.cs
@@ -1,0 +1,30 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneItemTransformChanged"/>
+    /// </summary>
+    public class SceneItemTransformEventArgs
+    {
+        /// <summary>
+        /// Name of the scene item is in
+        /// </summary>
+        public string SceneName { get; } 
+        
+        /// <summary>
+        /// Numeric ID of the scene item
+        /// </summary>
+        public string SceneItemId { get; } 
+        
+        /// <summary>
+        /// Transform data
+        /// </summary>
+        public SceneItemTransformInfo Transform { get; }
+
+        public SceneItemTransformEventArgs(string sceneName, string sceneItemId, SceneItemTransformInfo transform)
+        {
+            SceneName = sceneName;
+            SceneItemId = sceneItemId;
+            Transform = transform;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneListChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneListChangedEventArgs.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneListChanged"/>
+    /// </summary>
+    public class SceneListChangedEventArgs
+    {
+        /// <summary>
+        /// Updated array of scenes
+        /// </summary>
+        public List<JObject> Scenes { get; }
+
+        public SceneListChangedEventArgs(List<JObject> scenes)
+        {
+            Scenes = scenes;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneNameChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneNameChangedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneNameChanged"/>
+    /// </summary>
+    public class SceneNameChangedEventArgs
+    {
+        /// <summary>
+        /// Old name of the scene
+        /// </summary>
+        public string OldSceneName { get; }
+        
+        /// <summary>
+        /// New name of the scene
+        /// </summary>
+        public string SceneName { get; }
+
+        public SceneNameChangedEventArgs(string oldSceneName, string sceneName)
+        {
+            OldSceneName = oldSceneName;
+            SceneName = sceneName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneRemovedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneRemovedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneRemoved"/>
+    /// </summary>
+    public class SceneRemovedEventArgs
+    {
+        /// <summary>
+        /// Name of the removed scene
+        /// </summary>
+        public string SceneName { get; }
+        
+        /// <summary>
+        /// Whether the removed scene was a group
+        /// </summary>
+        public bool IsGroup { get; }
+
+        public SceneRemovedEventArgs(string sceneName, bool isGroup)
+        {
+            SceneName = sceneName;
+            IsGroup = isGroup;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneTransitionEndedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneTransitionEndedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneTransitionEnded"/>
+    /// </summary>
+    public class SceneTransitionEndedEventArgs
+    {
+        /// <summary>
+        /// Scene transition name
+        /// </summary>
+        public string TransitionName { get; }
+
+        public SceneTransitionEndedEventArgs(string transitionName)
+        {
+            TransitionName = transitionName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneTransitionStartedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneTransitionStartedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SceneTransitionStarted"/>
+    /// </summary>
+    public class SceneTransitionStartedEventArgs
+    {
+        /// <summary>
+        /// Transition name
+        /// </summary>
+        public string TransitionName { get; }
+
+        public SceneTransitionStartedEventArgs(string transitionName)
+        {
+            TransitionName = transitionName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SceneTransitionVideoEndedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SceneTransitionVideoEndedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Called by <see cref="OBSWebsocket.SceneTransitionVideoEnded"/>
+    /// </summary>
+    public class SceneTransitionVideoEndedEventArgs
+    {
+        /// <summary>
+        /// Transition name
+        /// </summary>
+        public string TransitionName { get; }
+
+        public SceneTransitionVideoEndedEventArgs(string transitionName)
+        {
+            TransitionName = transitionName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SourceFilterCreatedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SourceFilterCreatedEventArgs.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SourceFilterCreated"/>
+    /// </summary>
+    public class SourceFilterCreatedEventArgs
+    {
+        /// <summary>
+        /// Name of the source the filter was added to
+        /// </summary>
+        public string SourceName { get; }
+        
+        /// <summary>
+        /// Name of the filter
+        /// </summary>
+        public string FilterName{ get; }
+        
+        /// <summary>
+        /// The kind of the filter
+        /// </summary>
+        public string FilterKind{ get; }
+        
+        /// <summary>
+        /// Index position of the filter
+        /// </summary>
+        public int FilterIndex{ get; }
+        
+        /// <summary>
+        /// The settings configured to the filter when it was created
+        /// </summary>
+        public JObject FilterSettings{ get; }
+        
+        /// <summary>
+        /// The default settings for the filter
+        /// </summary>
+        public JObject DefaultFilterSettings { get; }
+
+        public SourceFilterCreatedEventArgs(string sourceName, string filterName, string filterKind, int filterIndex, JObject filterSettings, JObject defaultFilterSettings)
+        {
+            SourceName = sourceName;
+            FilterName = filterName;
+            FilterKind = filterKind;
+            FilterIndex = filterIndex;
+            FilterSettings = filterSettings;
+            DefaultFilterSettings = defaultFilterSettings;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SourceFilterEnableStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SourceFilterEnableStateChangedEventArgs.cs
@@ -1,0 +1,30 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SourceFilterEnableStateChanged"/>
+    /// </summary>
+    public class SourceFilterEnableStateChangedEventArgs
+    {
+        /// <summary>
+        /// Name of the source the filter is on
+        /// </summary>
+        public string SourceName { get; }
+        
+        /// <summary>
+        /// Name of the filter
+        /// </summary>
+        public string FilterName { get; } 
+        
+        /// <summary>
+        /// Whether the filter is enabled
+        /// </summary>
+        public bool FilterEnabled { get; }
+
+        public SourceFilterEnableStateChangedEventArgs(string sourceName, string filterName, bool filterEnabled)
+        {
+            SourceName = sourceName;
+            FilterName = filterName;
+            FilterEnabled = filterEnabled;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SourceFilterListReindexedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SourceFilterListReindexedEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using OBSWebsocketDotNet;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SourceFilterListReindexed"/>
+    /// </summary>
+    public class SourceFilterListReindexedEventArgs
+    {
+        /// <summary>
+        /// Name of the source
+        /// </summary>
+        public string SourceName { get; }
+        
+        /// <summary>
+        /// Array of filter objects
+        /// </summary>
+        public List<FilterReorderItem> Filters { get; }
+
+        public SourceFilterListReindexedEventArgs(string sourceName, List<FilterReorderItem> filters)
+        {
+            SourceName = sourceName;
+            Filters = filters;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SourceFilterNameChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SourceFilterNameChangedEventArgs.cs
@@ -1,0 +1,30 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SourceFilterNameChanged"/>
+    /// </summary>
+    public class SourceFilterNameChangedEventArgs
+    {
+        /// <summary>
+        /// The source the filter is on
+        /// </summary>
+        public string SourceName { get; } 
+        
+        /// <summary>
+        /// Old name of the filter
+        /// </summary>
+        public string OldFilterName { get; } 
+        
+        /// <summary>
+        /// New name of the filter
+        /// </summary>
+        public string FilterName { get; }
+
+        public SourceFilterNameChangedEventArgs(string sourceName, string oldFilterName, string filterName)
+        {
+            SourceName = sourceName;
+            OldFilterName = oldFilterName;
+            FilterName = filterName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/SourceFilterRemovedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/SourceFilterRemovedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.SourceFilterRemoved"/>
+    /// </summary>
+    public class SourceFilterRemovedEventArgs
+    {
+        /// <summary>
+        /// Name of the source the filter was on
+        /// </summary>
+        public string SourceName { get; }
+        
+        /// <summary>
+        /// Name of the filter
+        /// </summary>
+        public string FilterName { get; }
+
+        public SourceFilterRemovedEventArgs(string sourceName, string filterName)
+        {
+            SourceName = sourceName;
+            FilterName = filterName;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/StreamStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/StreamStateChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.StreamStateChanged"/>
+    /// </summary>
+    public class StreamStateChangedEventArgs
+    {
+        /// <summary>
+        /// The specific state of the output
+        /// </summary>
+        public OutputStateChanged OutputState { get; }
+
+        public StreamStateChangedEventArgs(OutputStateChanged outputState)
+        {
+            OutputState = outputState;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/StudioModeStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/StudioModeStateChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.StudioModeStateChanged"/>
+    /// </summary>
+    public class StudioModeStateChangedEventArgs
+    {
+        /// <summary>
+        /// New Studio Mode status
+        /// </summary>
+        public bool StudioModeEnabled { get; }
+
+        public StudioModeStateChangedEventArgs(bool studioModeEnabled)
+        {
+            StudioModeEnabled = studioModeEnabled;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/VendorEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/VendorEventArgs.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.VendorEvent"/>
+    /// </summary>
+    public class VendorEventArgs
+    {
+        /// <summary>
+        /// Name of the vendor emitting the event
+        /// </summary>
+        public string VendorName { get; }
+        
+        /// <summary>
+        /// Vendor-provided event typedef
+        /// </summary>
+        public string EventType { get; } 
+        
+        /// <summary>
+        /// Vendor-provided event data. {} if event does not provide any data
+        /// </summary>
+        public JObject eventData { get; }
+
+        public VendorEventArgs(string vendorName, string eventType, JObject eventData)
+        {
+            VendorName = vendorName;
+            EventType = eventType;
+            this.eventData = eventData;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/Events/VirtualcamStateChangedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/VirtualcamStateChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for <see cref="OBSWebsocket.VirtualcamStateChanged"/>
+    /// </summary>
+    public class VirtualcamStateChangedEventArgs
+    {
+        /// <summary>
+        /// The specific state of the output
+        /// </summary>
+        public OutputStateChanged OutputState { get; }
+
+        public VirtualcamStateChangedEventArgs(OutputStateChanged outputState)
+        {
+            OutputState = outputState;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/OutputStatus.cs
+++ b/obs-websocket-dotnet/Types/OutputStatus.cs
@@ -1,11 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace OBSWebsocketDotNet
+namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
     /// Status of streaming output

--- a/obs-websocket-dotnet/Types/VirtualCamStatus.cs
+++ b/obs-websocket-dotnet/Types/VirtualCamStatus.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace OBSWebsocketDotNet
+namespace OBSWebsocketDotNet.Types
 {
     /// <summary>
     /// VirtualCam Status


### PR DESCRIPTION
This should move all events exposed on the socket over to use regular `EventHandlers` as well as creating basic models for each event arg type.

While this may look like a LOT of change really all ive done is for each delegate make a custom event arg class then move all code over to use a regular event handler delegate with that new args model, then updated any code that was using that old delegate to use the new approach.