### PR TITLE
Allow to `await` ConnectAsync()

### DIFF
--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -305,11 +305,11 @@ namespace TestClient
         {
             if (!obs.IsConnected)
             {
-                System.Threading.Tasks.Task.Run(() =>
+                System.Threading.Tasks.Task.Run(async () =>
                 {
                     try
                     {
-                        obs.ConnectAsync(txtServerIP.Text, txtServerPassword.Text);
+                        await obs.ConnectAsync(txtServerIP.Text, txtServerPassword.Text);
                     }
                     catch (Exception ex)
                     {

--- a/obs-websocket-dotnet/IOBSWebsocket.cs
+++ b/obs-websocket-dotnet/IOBSWebsocket.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OBSWebsocketDotNet.Communication;
 using OBSWebsocketDotNet.Types;
@@ -1050,7 +1051,7 @@ namespace OBSWebsocketDotNet
         /// </summary>
         /// <param name="url">Server URL in standard URL format.</param>
         /// <param name="password">Server password</param>
-        void ConnectAsync(string url, string password);
+        Task ConnectAsync(string url, string password);
 
         /// <summary>
         /// Disconnect this instance from the server

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -85,6 +85,8 @@ namespace OBSWebsocketDotNet
         /// </summary>
         /// <param name="url">Server URL in standard URL format.</param>
         /// <param name="password">Server password</param>
+        /// <returns>Returns the awaitable Task from <see cref="WebsocketClient.StartOrFail"/>.
+        /// NOTE: After awaiting, the client is still not ready to work. Please subscribe to the Connected event to determine when the connection is actually fully established</returns>
         public Task ConnectAsync(string url, string password)
         {
             if (!url.ToLower().StartsWith(WEBSOCKET_URL_PREFIX))

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -85,7 +85,7 @@ namespace OBSWebsocketDotNet
         /// </summary>
         /// <param name="url">Server URL in standard URL format.</param>
         /// <param name="password">Server password</param>
-        public void ConnectAsync(string url, string password)
+        public Task ConnectAsync(string url, string password)
         {
             if (!url.ToLower().StartsWith(WEBSOCKET_URL_PREFIX))
             {
@@ -105,7 +105,7 @@ namespace OBSWebsocketDotNet
             wsConnection.DisconnectionHappened.Subscribe(d => Task.Run(() => OnWebsocketDisconnect(this, d)));
 
             connectionPassword = password;
-            wsConnection.StartOrFail();
+            return wsConnection.StartOrFail();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR does not change the behavior of this function in the already existing code.
But it allows you to wait for the connection attempt to complete.