### PR TITLE
Add SetRecordDirectory back

### DIFF
--- a/TestClient/MainWindow.Designer.cs
+++ b/TestClient/MainWindow.Designer.cs
@@ -432,7 +432,6 @@ namespace TestClient
             // btnBrowse
             // 
             this.btnBrowse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnBrowse.Enabled = false;
             this.btnBrowse.Location = new System.Drawing.Point(277, 29);
             this.btnBrowse.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnBrowse.Name = "btnBrowse";
@@ -454,7 +453,6 @@ namespace TestClient
             // btnSetPath
             // 
             this.btnSetPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSetPath.Enabled = false;
             this.btnSetPath.Location = new System.Drawing.Point(365, 28);
             this.btnSetPath.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.btnSetPath.Name = "btnSetPath";

--- a/TestClient/MainWindow.cs
+++ b/TestClient/MainWindow.cs
@@ -489,8 +489,7 @@ namespace TestClient
 
         private void btnSetPath_Click(object sender, EventArgs e)
         {
-            // TODO: Need a method here, or the button must be removed
-            //obs.SetRecordingFolder(tbFolderPath.Text);
+            obs.SetRecordDirectory(tbFolderPath.Text);
         }
 
         private void onVirtualCamStateChanged(object sender, VirtualcamStateChangedEventArgs args)

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -2152,5 +2152,21 @@ namespace OBSWebsocketDotNet
 
             SendRequest(nameof(OpenVideoMixProjector), request);
         }
+
+
+        /// <summary>
+        /// Sets the current directory that the record output writes files to.
+        /// </summary>
+        /// <param name="recordDirectory">Output directory</param>
+        public void SetRecordDirectory(string recordDirectory)
+        {
+            var requestFields = new JObject
+            {
+                { nameof(recordDirectory), recordDirectory }
+            };
+
+            SendRequest(nameof(SetRecordDirectory), requestFields);
+        }
+
     }
 }


### PR DESCRIPTION
Finally in obs-websocket v5.3.0 (which is released in OBS30), we have this API back.

Related doc page: https://github.com/obsproject/obs-websocket/blob/master/docs/generated/protocol.md#setrecorddirectory