### PR TITLE
#136: Writing error logs to an ILogger instead of Console, adding an event for Unsupported Events, and other fixes

### DIFF
--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -527,7 +527,7 @@ namespace OBSWebsocketDotNet
 
                 default:
                     var message = $"Unsupported Event: {eventType}\n{body}";
-                    Logger.LogInformation(message);
+                    Logger?.LogInformation(message);
                     UnsupportedEvent?.Invoke(this, new UnsupportedEventArgs(eventType, body));
                     break;
             }

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -291,6 +291,11 @@ namespace OBSWebsocketDotNet
         /// </summary>
         public event EventHandler<SceneNameChangedEventArgs> SceneNameChanged;
 
+        /// <summary>
+        /// An unsupported event has been received.
+        /// </summary>
+        public event EventHandler<UnsupportedEventArgs> UnsupportedEvent;
+
         #endregion
 
         #region EventProcessing
@@ -522,8 +527,8 @@ namespace OBSWebsocketDotNet
 
                 default:
                     var message = $"Unsupported Event: {eventType}\n{body}";
-                    Logger.LogWarning(message);
-                    Debug.WriteLine(message);
+                    Logger.LogInformation(message);
+                    UnsupportedEvent?.Invoke(this, new UnsupportedEventArgs(eventType, body));
                     break;
             }
         }

--- a/obs-websocket-dotnet/Events.cs
+++ b/obs-websocket-dotnet/Events.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using OBSWebsocketDotNet.Types.Events;
+using Microsoft.Extensions.Logging;
 
 namespace OBSWebsocketDotNet
 {
@@ -521,7 +522,7 @@ namespace OBSWebsocketDotNet
 
                 default:
                     var message = $"Unsupported Event: {eventType}\n{body}";
-                    Console.WriteLine(message);
+                    Logger.LogWarning(message);
                     Debug.WriteLine(message);
                     break;
             }

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -62,6 +62,9 @@ namespace OBSWebsocketDotNet
             }
         }
 
+        /// <summary>
+        /// Gets or sets the logger for this instance
+        /// </summary>
         public ILogger<OBSWebsocket> Logger { get; set; } = NullLogger<OBSWebsocket>.Instance;
 
         /// <summary>

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -8,6 +8,9 @@ using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using Websocket.Client;
 using OBSWebsocketDotNet.Communication;
+using Websocket.Client.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace OBSWebsocketDotNet
 {
@@ -58,6 +61,8 @@ namespace OBSWebsocketDotNet
                 return (wsConnection != null && wsConnection.IsRunning);
             }
         }
+
+        public ILogger<OBSWebsocket> Logger { get; set; } = NullLogger<OBSWebsocket>.Instance;
 
         /// <summary>
         /// Constructor

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OBSWebsocketDotNet.Types;
 using System;
@@ -339,7 +340,7 @@ namespace OBSWebsocketDotNet
             catch (Exception e)
             {
                 //TODO exception handling
-                Console.WriteLine(e.Message);
+                Logger.LogError(e, "Error removing filter");
             }
             return false;
         }

--- a/obs-websocket-dotnet/OBSWebsocket_Requests.cs
+++ b/obs-websocket-dotnet/OBSWebsocket_Requests.cs
@@ -340,7 +340,7 @@ namespace OBSWebsocketDotNet
             catch (Exception e)
             {
                 //TODO exception handling
-                Logger.LogError(e, "Error removing filter");
+                Logger?.LogError(e, "Error removing filter");
             }
             return false;
         }

--- a/obs-websocket-dotnet/Types/Events/UnsupportedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/UnsupportedEventArgs.cs
@@ -8,9 +8,18 @@ namespace OBSWebsocketDotNet.Types.Events
     /// </summary>
     public class UnsupportedEventArgs : EventArgs
     {
+        /// <summary>
+        /// The type of the event
+        /// </summary>
         public string EventType { get; }
+        /// <summary>
+        /// The body of the event
+        /// </summary>
         public JObject Body { get; }
 
+        /// <summary>
+        /// Event args for unsupported events
+        /// </summary>
         public UnsupportedEventArgs(string eventType, JObject body)
         {
             EventType = eventType;

--- a/obs-websocket-dotnet/Types/Events/UnsupportedEventArgs.cs
+++ b/obs-websocket-dotnet/Types/Events/UnsupportedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace OBSWebsocketDotNet.Types.Events
+{
+    /// <summary>
+    /// Event args for unsupported events
+    /// </summary>
+    public class UnsupportedEventArgs : EventArgs
+    {
+        public string EventType { get; }
+        public JObject Body { get; }
+
+        public UnsupportedEventArgs(string eventType, JObject body)
+        {
+            EventType = eventType;
+            Body = body;
+        }
+    }
+}

--- a/obs-websocket-dotnet/Types/MediaInputStatus.cs
+++ b/obs-websocket-dotnet/Types/MediaInputStatus.cs
@@ -57,15 +57,49 @@ namespace OBSWebsocketDotNet.Types
         public MediaInputStatus() { }
     }
 
+    /// <summary>
+    /// Enum representing the state of a media input
+    /// </summary>
     public enum MediaState
     {
+        /// <summary>
+        /// No media is loaded
+        /// </summary>
         OBS_MEDIA_STATE_NONE,
+
+        /// <summary>
+        /// Media is playing
+        /// </summary>
         OBS_MEDIA_STATE_PLAYING,
+
+        /// <summary>
+        /// Media is opening
+        /// </summary>
         OBS_MEDIA_STATE_OPENING,
+
+        /// <summary>
+        /// Media is buffering
+        /// </summary>
         OBS_MEDIA_STATE_BUFFERING,
-        OBS_MEDIA_STATE_PAUSED,
+
+        /// <summary>
+        /// Media is playing but is paused
+        /// </summary>
+        OBS_MEDIA_STATE_PAUSED, 
+
+        /// <summary>
+        /// Media is stopped
+        /// </summary>
         OBS_MEDIA_STATE_STOPPED,
+
+        /// <summary>
+        /// Media is ended
+        /// </summary>
         OBS_MEDIA_STATE_ENDED,
+
+        /// <summary>
+        /// Media has errored
+        /// </summary>
         OBS_MEDIA_STATE_ERROR
     }
 }

--- a/obs-websocket-dotnet/Types/MediaInputStatus.cs
+++ b/obs-websocket-dotnet/Types/MediaInputStatus.cs
@@ -13,7 +13,7 @@ namespace OBSWebsocketDotNet.Types
         /// State of the media input
         /// </summary>
         [JsonProperty(PropertyName = "mediaState")]
-        internal string StateString { get; set; }
+        public string StateString { get; set; }
 
         /// <summary>
         /// State of the media input

--- a/obs-websocket-dotnet/Types/MediaInputStatus.cs
+++ b/obs-websocket-dotnet/Types/MediaInputStatus.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace OBSWebsocketDotNet.Types
@@ -12,19 +13,34 @@ namespace OBSWebsocketDotNet.Types
         /// State of the media input
         /// </summary>
         [JsonProperty(PropertyName = "mediaState")]
-        public string State { get; set; }
+        internal string StateString { get; set; }
+
+        /// <summary>
+        /// State of the media input
+        /// </summary>
+        public MediaState? State
+        {
+            get
+            {
+                if (!Enum.TryParse(StateString, out MediaState state))
+                {
+                    return null;
+                }
+                return state;
+            }
+        }
 
         /// <summary>
         /// Total duration of the playing media in milliseconds. `null` if not playing
         /// </summary>
         [JsonProperty(PropertyName = "mediaDuration")]
-        public int? Duration { get; set; }
+        public long? Duration { get; set; }
 
         /// <summary>
         /// Position of the cursor in milliseconds. `null` if not playing
         /// </summary>
         [JsonProperty(PropertyName = "mediaCursor")]
-        public int Cursor { get; set; }
+        public long? Cursor { get; set; }
 
         /// <summary>
         /// Instantiate from JObject
@@ -39,5 +55,17 @@ namespace OBSWebsocketDotNet.Types
         /// Default Constructor
         /// </summary>
         public MediaInputStatus() { }
+    }
+
+    public enum MediaState
+    {
+        OBS_MEDIA_STATE_NONE,
+        OBS_MEDIA_STATE_PLAYING,
+        OBS_MEDIA_STATE_OPENING,
+        OBS_MEDIA_STATE_BUFFERING,
+        OBS_MEDIA_STATE_PAUSED,
+        OBS_MEDIA_STATE_STOPPED,
+        OBS_MEDIA_STATE_ENDED,
+        OBS_MEDIA_STATE_ERROR
     }
 }

--- a/obs-websocket-dotnet/Types/OBSVideoSettings.cs
+++ b/obs-websocket-dotnet/Types/OBSVideoSettings.cs
@@ -11,36 +11,36 @@ namespace OBSWebsocketDotNet.Types
         /// Numerator of the fractional FPS value
         /// </summary>
         [JsonProperty(PropertyName = "fpsNumerator")]
-        public double FpsNumerator { internal set; get; }
+        public double FpsNumerator { set; get; }
 
         /// <summary>
         /// Denominator of the fractional FPS value
         /// </summary>
         [JsonProperty(PropertyName = "fpsDenominator")]
-        public double FpsDenominator { internal set; get; }
+        public double FpsDenominator { set; get; }
 
         /// <summary>
         /// Base (canvas) width
         /// </summary>
         [JsonProperty(PropertyName = "baseWidth")]
-        public int BaseWidth { internal set; get; }
+        public int BaseWidth { set; get; }
 
         /// <summary>
         /// Base (canvas) height
         /// </summary>
         [JsonProperty(PropertyName = "baseHeight")]
-        public int BaseHeight { internal set; get; }
+        public int BaseHeight { set; get; }
 
         /// <summary>
         /// Width of the output resolution in pixels
         /// </summary>
         [JsonProperty(PropertyName = "outputWidth")]
-        public int OutputWidth { internal set; get; }
+        public int OutputWidth { set; get; }
 
         /// <summary>
         /// Height of the output resolution in pixels
         /// </summary>
         [JsonProperty(PropertyName = "outputHeight")]
-        public int OutputHeight { internal set; get; }
+        public int OutputHeight { set; get; }
     }
 }

--- a/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
+++ b/obs-websocket-dotnet/Types/StreamingServiceSettings.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace OBSWebsocketDotNet.Types
 {
@@ -36,5 +38,23 @@ namespace OBSWebsocketDotNet.Types
         /// </summary>
         [JsonProperty(PropertyName = "password")]
         public string Password { set; get; }
+
+        /// <summary>
+        /// The service being used to stream
+        /// </summary>
+        [JsonProperty(PropertyName = "service")]
+        public string Service { get; set; }
+
+        /// <summary>
+        /// The protocol to use for the stream
+        /// </summary>
+        [JsonProperty(PropertyName = "protocol")]
+        public string Protocol { get; set; }
+
+        /// <summary>
+        /// Other values not covered by the class
+        /// </summary>
+        [JsonExtensionData]
+        public Dictionary<string, JToken> OtherValues { get; set; }
     }
 }

--- a/obs-websocket-dotnet/obs-websocket-dotnet.csproj
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.csproj
@@ -28,7 +28,7 @@ What's new in v5.0.0.3
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-	  <DocumentationFile>E:\Projects\GitHub\obs-websocket-dotnet-standard\obs-websocket-dotnet\obs-websocket-dotnet.xml</DocumentationFile>
+	  <DocumentationFile>obs-websocket-dotnet.xml</DocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/obs-websocket-dotnet/obs-websocket-dotnet.csproj
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.csproj
@@ -32,6 +32,7 @@ What's new in v5.0.0.3
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	  <PackageReference Include="Websocket.Client" Version="4.4.43" />
 	</ItemGroup>

--- a/obs-websocket-dotnet/obs-websocket-dotnet.xml
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.xml
@@ -5208,6 +5208,21 @@
             The password to use when accessing the streaming server. Only present if use-auth is true
             </summary>
         </member>
+        <member name="P:OBSWebsocketDotNet.Types.StreamingServiceSettings.Service">
+            <summary>
+            The service being used to stream
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.StreamingServiceSettings.Protocol">
+            <summary>
+            The protocol to use for the stream
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.StreamingServiceSettings.OtherValues">
+            <summary>
+            Other values not covered by the class
+            </summary>
+        </member>
         <member name="T:OBSWebsocketDotNet.Types.TransitionOverrideInfo">
             <summary>
             Scene transition override settings

--- a/obs-websocket-dotnet/obs-websocket-dotnet.xml
+++ b/obs-websocket-dotnet/obs-websocket-dotnet.xml
@@ -4,357 +4,143 @@
         <name>obs-websocket-dotnet</name>
     </assembly>
     <members>
-        <member name="T:OBSWebsocketDotNet.SceneChangeCallback">
+        <member name="T:OBSWebsocketDotNet.Communication.OBSAuthInfo">
             <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="newSceneName">Name of the new current scene</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceOrderChangeCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceOrderChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sceneName">Name of the scene where items where reordered</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SceneItemUpdateCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemAdded"/>
-            or <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemRemoved"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sceneName">Name of the scene where the item is</param>
-            <param name="itemName">Name of the concerned item</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SceneItemVisibilityChangedCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemVisibilityChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sceneName">Name of the scene where the item is</param>
-            <param name="itemName">Name of the concerned item</param>
-            <param name="isVisible">Visibility of the item</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SceneItemLockChangedCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemLockChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sceneName">Name of the scene where the item is</param>
-            <param name="itemName">Name of the concerned item</param>
-            <param name="itemId">Id of the concerned item</param>
-            <param name="isLocked">Lock status of the item</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.TransitionChangeCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.TransitionChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="newTransitionName">Name of the new selected transition</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.TransitionDurationChangeCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.TransitionDurationChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="newDuration">Name of the new transition duration (in milliseconds)</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.TransitionBeginCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.TransitionBegin"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="transitionName">Transition name</param>
-            <param name="transitionType">Transition type</param>
-            <param name="duration">Transition duration (in milliseconds). Will be -1 for any transition with a fixed duration, such as a Stinger, due to limitations of the OBS API</param>
-            <param name="fromScene">Source scene of the transition</param>
-            <param name="toScene">Destination scene of the transition</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.TransitionEndCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.TransitionEnd"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="transitionName">Transition name</param>
-            <param name="transitionType">Transition type</param>
-            <param name="duration">Transition duration (in milliseconds).</param>
-            <param name="toScene">Destination scene of the transition</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.TransitionVideoEndCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.TransitionVideoEnd"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="transitionName">Transition name</param>
-            <param name="transitionType">Transition type</param>
-            <param name="duration">Transition duration (in milliseconds).</param>
-            <param name="fromScene">Source scene of the transition</param>
-            <param name="toScene">Destination scene of the transition</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.OutputStateCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.StreamingStateChanged"/>, <see cref="E:OBSWebsocketDotNet.OBSWebsocket.RecordingStateChanged"/>
-            or <see cref="E:OBSWebsocketDotNet.OBSWebsocket.ReplayBufferStateChanged"/> 
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="type">New output state</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.StreamStatusCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.StreamStatus"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="status">Stream status data</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.StudioModeChangeCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.StudioModeSwitched"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="enabled">New Studio Mode status</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.HeartBeatCallback">
-            <summary>
-            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.Heartbeat"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="heatbeat">heartbeat data</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SceneItemDeselectedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemDeselected"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sceneName">Name of the scene item was in</param>
-            <param name="itemName">Name of the item deselected</param>
-            <param name="itemId">Id of the item deselected</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SceneItemSelectedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemSelected"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sceneName">Name of the scene item was in</param>
-            <param name="itemName">Name of the item seletected</param>
-            <param name="itemId">Id of the item selected</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SceneItemTransformCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemTransformChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="transform">Transform data</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceAudioMixersChangedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioMixersChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="mixerInfo">Mixer information that was updated</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceAudioSyncOffsetCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioSyncOffsetChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of the source for the offset change</param>
-            <param name="syncOffset">Sync offset value</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceCreatedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceCreated"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="settings">Newly created source settings</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceDestroyedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceDestroyed"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Newly destroyed source information</param>
-            <param name="sourceKind">Kind of source destroyed</param>
-            <param name="sourceType">Type of source destroyed</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceRenamedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceRenamed"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="newName">New name of source</param>
-            <param name="previousName">Previous name of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceMuteStateChangedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceMuteStateChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="muted">Current mute state of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceAudioDeactivatedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioDeactivated"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceAudioActivatedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioActivated"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceVolumeChangedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceVolumeChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="volume">Current volume levels of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceFilterRemovedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterRemoved"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="filterName">Name of removed filter</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceFilterAddedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterAdded"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="filterName">Name of filter</param>
-            <param name="filterType">Type of filter</param>
-            <param name="filterSettings">Settings for filter</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceFiltersReorderedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFiltersReordered"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="filters">Current order of filters for source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.SourceFilterVisibilityChangedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterVisibilityChanged"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="filterName">Name of filter</param>
-            <param name="filterEnabled">New filter state</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.BroadcastCustomMessageCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.BroadcastCustomMessageReceived"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="realm">Identifier provided by the sender</param>
-            <param name="data">User-defined data</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaEndedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaEnded"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaStartedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaStarted"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaPreviousCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaPrevious"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaNextCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaNext"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaStoppedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaStopped"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaRestartedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaRestarted"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaPausedCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaPaused"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.MediaPlayingCallback">
-            <summary>
-            Callback by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaPlaying"/>
-            </summary>
-            <param name="sender"><see cref="T:OBSWebsocketDotNet.OBSWebsocket"/> instance</param>
-            <param name="sourceName">Name of source</param>
-            <param name="sourceKind">Kind of source</param>
-        </member>
-        <member name="T:OBSWebsocketDotNet.AuthFailureException">
-            <summary>
-            Thrown if authentication fails
+            Data required by authentication
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.ErrorResponseException">
+        <member name="F:OBSWebsocketDotNet.Communication.OBSAuthInfo.Challenge">
             <summary>
-            Thrown when the server responds with an error
+            Authentication challenge
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.ErrorResponseException.#ctor(System.String)">
+        <member name="F:OBSWebsocketDotNet.Communication.OBSAuthInfo.PasswordSalt">
+            <summary>
+            Password salt
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Communication.OBSAuthInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Builds the object from JSON response body
+            </summary>
+            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Communication.OBSAuthInfo.#ctor">
+            <summary>
+            Default Constructor for deserialization
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Communication.ObsCloseCodes">
+            <summary>
+            Close/Error codes sent by OBS Websocket when closing the connection
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.DontClose">
+            <summary>
+            For internal use only to tell the request handler not to perform any close action.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.UnknownReason">
+            <summary>
+            Unknown reason, should never be used.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.MessageDecodeError">
+            <summary>
+            The server was unable to decode the incoming websocket message.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.MissingDataField">
+            <summary>
+            A data field is required but missing from the payload.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.InvalidDataFieldType">
+            <summary>
+            A data field's value type is invalid.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.InvalidDataFieldValue">
+            <summary>
+            A data field's value is invalid.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.UnknownOpCode">
+            <summary>
+            The specified op was invalid or missing.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.NotIdentified">
+            <summary>
+            The client sent a websocket message without first sending Identify message.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.AlreadyIdentified">
+            <summary>
+            The client sent an Identify message while already identified.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.AuthenticationFailed">
+            <summary>
+            The authentication attempt (via Identify) failed.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.UnsupportedRpcVersion">
+            <summary>
+            The server detected the usage of an old version of the obs-websocket RPC protocol.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.SessionInvalidated">
+            <summary>
+            The websocket session has been invalidated by the obs-websocket server.
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Communication.ObsCloseCodes.UnsupportedFeature">
+            <summary>
+            A requested feature is not supported due to hardware/software limitations.
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Communication.ObsDisconnectionInfo">
+            <summary>
+            Disconnection information received from the OBS Websocket server
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Communication.ObsDisconnectionInfo.ObsCloseCode">
+            <summary>
+            Close/Error codes sent by OBS Websocket when closing the connection
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Communication.ObsDisconnectionInfo.DisconnectReason">
+            <summary>
+            String reason of disconnect
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Communication.ObsDisconnectionInfo.WebsocketDisconnectionInfo">
+            <summary>
+            Websocket Client internal information
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Communication.ObsDisconnectionInfo.#ctor(OBSWebsocketDotNet.Communication.ObsCloseCodes,System.String,Websocket.Client.DisconnectionInfo)">
             <summary>
             Constructor
             </summary>
-            <param name="message"></param>
+            <param name="obsCloseCode">Close/Error codes sent by OBS Websocket when closing the connection</param>
+            <param name="disconnectReason">String reason of disconnect</param>
+            <param name="websocketDisconnectionInfo">Websocket Client internal information</param>
         </member>
-        <member name="T:OBSWebsocketDotNet.MediaSourceSettings">
+        <member name="T:OBSWebsocketDotNet.Communication.ServerMessage">
             <summary>
-            
+            Message received from the server
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.MediaSourceSettings.SourceName">
+        <member name="P:OBSWebsocketDotNet.Communication.ServerMessage.OperationCode">
             <summary>
-            Source Name
+            Server Message's operation code
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.MediaSourceSettings.SourceType">
+        <member name="P:OBSWebsocketDotNet.Communication.ServerMessage.Data">
             <summary>
-            Source Type
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.MediaSourceSettings.Media">
-            <summary>
-            Media settings
+            Server Data
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.OBSWebsocket">
@@ -362,22 +148,23 @@
             Instance of a connection with an obs-websocket server
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProgramSceneChanged">
             <summary>
-            Triggered when switching to another scene
+            The current program scene has changed.
             </summary>
         </member>
         <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneListChanged">
             <summary>
-            Triggered when a scene is created, deleted or renamed
+            The list of scenes has changed.
+            TODO: Make OBS fire this event when scenes are reordered.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceOrderChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemListReindexed">
             <summary>
             Triggered when the scene item list of the specified scene is reordered
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemAdded">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemCreated">
             <summary>
             Triggered when a new item is added to the item list of the specified scene
             </summary>
@@ -387,17 +174,17 @@
             Triggered when an item is removed from the item list of the specified scene
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemVisibilityChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemEnableStateChanged">
             <summary>
             Triggered when the visibility of a scene item changes
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemLockChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemLockStateChanged">
             <summary>
             Triggered when the lock status of a scene item changes
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneCollectionChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneCollectionChanged">
             <summary>
             Triggered when switching to another scene collection
             </summary>
@@ -407,37 +194,32 @@
             Triggered when a scene collection is created, deleted or renamed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.TransitionChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneTransitionChanged">
             <summary>
             Triggered when switching to another transition
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.TransitionDurationChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneTransitionDurationChanged">
             <summary>
             Triggered when the current transition duration is changed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.TransitionListChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneTransitionStarted">
             <summary>
-            Triggered when a transition is created or removed
+            Triggered when a transition between two scenes starts. Followed by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProgramSceneChanged"/>
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.TransitionBegin">
-            <summary>
-            Triggered when a transition between two scenes starts. Followed by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneChanged"/>
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.TransitionEnd">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneTransitionEnded">
             <summary>
             Triggered when a transition (other than "cut") has ended. Please note that the from-scene field is not available in TransitionEnd
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.TransitionVideoEnd">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneTransitionVideoEnded">
             <summary>
             Triggered when a stinger transition has finished playing its video
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.ProfileChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProfileChanged">
             <summary>
             Triggered when switching to another profile
             </summary>
@@ -447,24 +229,14 @@
             Triggered when a profile is created, imported, removed or renamed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.StreamingStateChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.StreamStateChanged">
             <summary>
             Triggered when the streaming output state changes
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.RecordingStateChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.RecordStateChanged">
             <summary>
             Triggered when the recording output state changes
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.RecordingPaused">
-            <summary>
-            Triggered when the recording output is paused
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.RecordingResumed">
-            <summary>
-            Triggered when the recording output is resumed
             </summary>
         </member>
         <member name="E:OBSWebsocketDotNet.OBSWebsocket.ReplayBufferStateChanged">
@@ -472,22 +244,17 @@
             Triggered when state of the replay buffer changes
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.StreamStatus">
-            <summary>
-            Triggered every 2 seconds while streaming is active
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.PreviewSceneChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentPreviewSceneChanged">
             <summary>
             Triggered when the preview scene selection changes (Studio Mode only)
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.StudioModeSwitched">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.StudioModeStateChanged">
             <summary>
             Triggered when Studio Mode is turned on or off
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.OBSExit">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.ExitStarted">
             <summary>
             Triggered when OBS exits
             </summary>
@@ -502,19 +269,9 @@
             Triggered when disconnected from an obs-websocket server
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.Heartbeat">
-            <summary>
-            Emitted every 2 seconds after enabling it by calling SetHeartbeat
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemDeselected">
-            <summary>
-            A scene item is deselected
-            </summary>
-        </member>
         <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemSelected">
             <summary>
-            A scene item is selected
+            A scene item is selected in the UI
             </summary>
         </member>
         <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemTransformChanged">
@@ -522,27 +279,12 @@
             A scene item transform has changed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioMixersChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioSyncOffsetChanged">
             <summary>
-            Audio mixer routing changed on a source
+            The audio sync offset of an input has changed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioSyncOffsetChanged">
-            <summary>
-            The audio sync offset of a source has changed
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceCreated">
-            <summary>
-            A source has been created. A source can be an input, a scene or a transition.
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceDestroyed">
-            <summary>
-            A source has been destroyed/removed. A source can be an input, a scene or a transition.
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterAdded">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterCreated">
             <summary>
             A filter was added to a source
             </summary>
@@ -552,95 +294,148 @@
             A filter was removed from a source
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFiltersReordered">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterListReindexed">
             <summary>
             Filters in a source have been reordered
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterVisibilityChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterEnableStateChanged">
             <summary>
             Triggered when the visibility of a filter has changed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceMuteStateChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputMuteStateChanged">
             <summary>
             A source has been muted or unmuted
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioDeactivated">
-            <summary>
-            A source has been muted or unmuted
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceAudioActivated">
-            <summary>
-            A source has been muted or unmuted
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceRenamed">
-            <summary>
-            A source has been renamed
-            </summary>
-        </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceVolumeChanged">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputVolumeChanged">
             <summary>
             The volume of a source has changed
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.BroadcastCustomMessageReceived">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.VendorEvent">
             <summary>
             A custom broadcast message was received
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaEnded">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaInputPlaybackEnded">
             <summary>
             These events are emitted by the OBS sources themselves. For example when the media file ends. The behavior depends on the type of media source being used.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaStarted">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaInputPlaybackStarted">
             <summary>
             These events are emitted by the OBS sources themselves. For example when the media file starts playing. The behavior depends on the type of media source being used.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaPrevious">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaInputActionTriggered">
             <summary>
             This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaNext">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.VirtualcamStateChanged">
             <summary>
-            This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
+            The virtual cam state has changed.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaStopped">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneCollectionChanging">
             <summary>
-            This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
+            The current scene collection has begun changing.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaRestarted">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProfileChanging">
             <summary>
-            This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
+            The current profile has begun changing.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaPaused">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterNameChanged">
             <summary>
-            This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
+            The name of a source filter has changed.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.MediaPlaying">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputCreated">
             <summary>
-            This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
+            An input has been created.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.VirtualCameraStarted">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputRemoved">
             <summary>
-            The virtual camera has been started.
+            An input has been removed.
             </summary>
         </member>
-        <member name="E:OBSWebsocketDotNet.OBSWebsocket.VirtualCameraStopped">
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputNameChanged">
             <summary>
-            The virtual camera has been stopped.
+            The name of an input has changed.
             </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputActiveStateChanged">
+            <summary>
+            An input's active state has changed.
+            When an input is active, it means it's being shown by the program feed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputShowStateChanged">
+            <summary>
+            An input's show state has changed.
+            When an input is showing, it means it's being shown by the preview or a dialog.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioBalanceChanged">
+            <summary>
+            The audio balance value of an input has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioTracksChanged">
+            <summary>
+            The audio tracks of an input have changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioMonitorTypeChanged">
+            <summary>
+            The monitor type of an input has changed.
+            Available types are:
+            - `OBS_MONITORING_TYPE_NONE`
+            - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+            - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.InputVolumeMeters">
+            <summary>
+            A high-volume event providing volume levels of all active inputs every 50 milliseconds.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.ReplayBufferSaved">
+            <summary>
+            The replay buffer has been saved.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneCreated">
+            <summary>
+            A new scene has been created.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneRemoved">
+            <summary>
+            A scene has been removed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.SceneNameChanged">
+            <summary>
+            The name of a scene has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.OBSWebsocket.UnsupportedEvent">
+            <summary>
+            An unsupported event has been received.
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ProcessEventType(System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Update message handler
+            </summary>
+            <param name="eventType">Value of "event-type" in the JSON body</param>
+            <param name="body">full JSON message body</param>
         </member>
         <member name="P:OBSWebsocketDotNet.OBSWebsocket.WSTimeout">
             <summary>
@@ -652,9 +447,9 @@
             Current connection state
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.OBSWebsocket.WSConnection">
+        <member name="P:OBSWebsocketDotNet.OBSWebsocket.Logger">
             <summary>
-            Underlying WebSocket connection to an obs-websocket server. Value is null when disconnected.
+            Gets or sets the logger for this instance
             </summary>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.#ctor">
@@ -664,7 +459,16 @@
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.Connect(System.String,System.String)">
             <summary>
-            Connect this instance to the specified URL, and authenticate (if needed) with the specified password
+            Connect this instance to the specified URL, and authenticate (if needed) with the specified password.
+            NOTE: Please subscribe to the Connected/Disconnected events (or atleast check the IsConnected property) to determine when the connection is actually fully established
+            </summary>
+            <param name="url">Server URL in standard URL format.</param>
+            <param name="password">Server password</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ConnectAsync(System.String,System.String)">
+            <summary>
+            Connect this instance to the specified URL, and authenticate (if needed) with the specified password.
+            NOTE: Please subscribe to the Connected/Disconnected events (or atleast check the IsConnected property) to determine when the connection is actually fully established
             </summary>
             <param name="url">Server URL in standard URL format.</param>
             <param name="password">Server password</param>
@@ -682,32 +486,30 @@
             <param name="additionalFields">additional JSON fields if required by the request type</param>
             <returns>The server's JSON response as a JObject</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetVersion">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SendRequest(OBSWebsocketDotNet.Communication.MessageTypes,System.String,Newtonsoft.Json.Linq.JObject,System.Boolean)">
             <summary>
-            Requests version info regarding obs-websocket, the API and OBS Studio
+            Internal version which allows to set the opcode
+            Sends a message to the websocket API with the specified request type and optional parameters
             </summary>
-            <returns>Version info in an <see cref="T:OBSWebsocketDotNet.Types.OBSVersion"/> object</returns>
+            <param name="operationCode">Type/OpCode for this messaage</param>
+            <param name="requestType">obs-websocket request type, must be one specified in the protocol specification</param>
+            <param name="additionalFields">additional JSON fields if required by the request type</param>
+            <param name="waitForReply">Should wait for reply vs "fire and forget"</param>
+            <returns>The server's JSON response as a JObject</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetAuthInfo">
             <summary>
             Request authentication data. You don't have to call this manually.
             </summary>
-            <returns>Authentication data in an <see cref="T:OBSWebsocketDotNet.Types.OBSAuthInfo"/> object</returns>
+            <returns>Authentication data in an <see cref="T:OBSWebsocketDotNet.Communication.OBSAuthInfo"/> object</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.Authenticate(System.String,OBSWebsocketDotNet.Types.OBSAuthInfo)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SendIdentify(System.String,OBSWebsocketDotNet.Communication.OBSAuthInfo)">
             <summary>
-            Authenticates to the Websocket server using the challenge and salt given in the passed <see cref="T:OBSWebsocketDotNet.Types.OBSAuthInfo"/> object
+            Authenticates to the Websocket server using the challenge and salt given in the passed <see cref="T:OBSWebsocketDotNet.Communication.OBSAuthInfo"/> object
             </summary>
             <param name="password">User password</param>
             <param name="authInfo">Authentication data</param>
             <returns>true if authentication succeeds, false otherwise</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ProcessEventType(System.String,Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Update message handler
-            </summary>
-            <param name="eventType">Value of "event-type" in the JSON body</param>
-            <param name="body">full JSON message body</param>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.HashEncode(System.String)">
             <summary>
@@ -723,30 +525,37 @@
             <param name="length">(optional) message ID length</param>
             <returns>A random string of alphanumerical characters</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetVideoInfo">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetVideoSettings">
             <summary>
             Get basic OBS video information
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TakeSourceScreenshot(System.String,System.String,System.String,System.Int32,System.Int32)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SaveSourceScreenshot(System.String,System.String,System.String,System.Int32,System.Int32,System.Int32)">
             <summary>
-            At least embedPictureFormat or saveToFilePath must be specified.
-            Clients can specify width and height parameters to receive scaled pictures. Aspect ratio is preserved if only one of these two parameters is specified.
+            Saves a screenshot of a source to the filesystem.
+            The `imageWidth` and `imageHeight` parameters are treated as \"scale to inner\", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+            If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+            **Compatible with inputs and scenes.**
             </summary>
-            <param name="sourceName"></param>
-            <param name="embedPictureFormat">Format of the Data URI encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)</param>
-            <param name="saveToFilePath">Full file path (file extension included) where the captured image is to be saved. Can be in a format different from pictureFormat. Can be a relative path.</param>
-            <param name="width">Screenshot width. Defaults to the source's base width.</param>
-            <param name="height">Screenshot height. Defaults to the source's base height.</param>
+            <param name="sourceName">Name of the source to take a screenshot of</param>
+            <param name="imageFormat">Image compression format to use. Use `GetVersion` to get compatible image formats</param>
+            <param name="imageFilePath">Path to save the screenshot file to. Eg. `C:\\Users\\user\\Desktop\\screenshot.png`</param>
+            <param name="imageWidth">Width to scale the screenshot to</param>
+            <param name="imageHeight">Height to scale the screenshot to</param>
+            <param name="imageCompressionQuality">Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use \"default\" (whatever that means, idk)</param>
+            <returns>Base64-encoded screenshot string</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TakeSourceScreenshot(System.String,System.String,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SaveSourceScreenshot(System.String,System.String,System.String)">
             <summary>
-            At least embedPictureFormat or saveToFilePath must be specified.
-            Clients can specify width and height parameters to receive scaled pictures. Aspect ratio is preserved if only one of these two parameters is specified.
+            Saves a screenshot of a source to the filesystem.
+            The `imageWidth` and `imageHeight` parameters are treated as \"scale to inner\", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+            If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+            **Compatible with inputs and scenes.**
             </summary>
-            <param name="sourceName"></param>
-            <param name="embedPictureFormat">Format of the Data URI encoded picture. Can be "png", "jpg", "jpeg" or "bmp" (or any other value supported by Qt's Image module)</param>
-            <param name="saveToFilePath">Full file path (file extension included) where the captured image is to be saved. Can be in a format different from pictureFormat. Can be a relative path.</param>
+            <param name="sourceName">Name of the source to take a screenshot of</param>
+            <param name="imageFormat">Image compression format to use. Use `GetVersion` to get compatible image formats</param>
+            <param name="imageFilePath">Path to save the screenshot file to. Eg. `C:\\Users\\user\\Desktop\\screenshot.png`</param>
+            <returns>Base64-encoded screenshot string</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.TriggerHotkeyByName(System.String)">
             <summary>
@@ -754,30 +563,24 @@
             </summary>
             <param name="hotkeyName">Unique name of the hotkey, as defined when registering the hotkey (e.g. "ReplayBuffer.Save")</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TriggerHotkeyBySequence(OBSWebsocketDotNet.Types.OBSHotkey,OBSWebsocketDotNet.Types.KeyModifier)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TriggerHotkeyByKeySequence(OBSWebsocketDotNet.Types.OBSHotkey,OBSWebsocketDotNet.Types.KeyModifier)">
             <summary>
-            EExecutes hotkey routine, identified by bound combination of keys. A single key combination might trigger multiple hotkey routines depending on user settings
+            Triggers a hotkey using a sequence of keys.
             </summary>
-            <param name="key">Main key identifier (e.g. OBS_KEY_A for key "A"). Available identifiers are here: https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hotkeys.h</param>
+            <param name="keyId">Main key identifier (e.g. OBS_KEY_A for key "A"). Available identifiers are here: https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hotkeys.h</param>
             <param name="keyModifier">Optional key modifiers object. You can combine multiple key operators. e.g. KeyModifier.Shift | KeyModifier.Control</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentScene">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentProgramScene">
             <summary>
-            Get the current scene info along with its items
+            Get the name of the currently active scene. 
             </summary>
-            <returns>An <see cref="T:OBSWebsocketDotNet.Types.OBSScene"/> object describing the current scene</returns>
+            <returns>Name of the current scene</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentScene(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentProgramScene(System.String)">
             <summary>
             Set the current scene to the specified one
             </summary>
             <param name="sceneName">The desired scene name</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetFilenameFormatting">
-            <summary>
-            Get the filename formatting string
-            </summary>
-            <returns>Current filename formatting string</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStats">
             <summary>
@@ -788,84 +591,27 @@
             <summary>
             List every available scene
             </summary>
-            <returns>A <see cref="T:System.Collections.Generic.List`1" /> of <see cref="T:OBSWebsocketDotNet.Types.OBSScene"/> objects describing each scene</returns>
+            <returns>A <see cref="T:System.Collections.Generic.List`1" /> of <see cref="T:OBSWebsocketDotNet.Types.SceneBasicInfo"/> objects describing each scene</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneList">
             <summary>
             Get a list of scenes in the currently active profile
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ReorderSceneItems(System.Collections.Generic.List{OBSWebsocketDotNet.Types.SceneItemStub},System.String)">
-            <summary>
-            Changes the order of scene items in the requested scene
-            </summary>
-            <param name="sceneName">Name of the scene to reorder (defaults to current)</param>
-            <param name="sceneItems">List of items to reorder, only ID or Name required</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneTransitionOverride(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneSceneTransitionOverride(System.String)">
             <summary>
             Get the specified scene's transition override info
             </summary>
             <param name="sceneName">Name of the scene to return the override info</param>
             <returns>TransitionOverrideInfo</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneTransitionOverride(System.String,System.String,System.Int32)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneSceneTransitionOverride(System.String,System.String,System.Int32)">
             <summary>
             Set specific transition override for a scene
             </summary>
             <param name="sceneName">Name of the scene to set the transition override</param>
             <param name="transitionName">Name of the transition to use</param>
             <param name="transitionDuration">Duration in milliseconds of the transition if transition is not fixed. Defaults to the current duration specified in the UI if there is no current override and this value is not given</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveSceneTransitionOverride(System.String)">
-            <summary>
-            Remove any transition override from a specific scene
-            </summary>
-            <param name="sceneName">Name of the scene to remove the transition override</param>
-        </member>
-      <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputList">
-        <summary>
-          Get a list of all inputs in the scene collection
-        </summary>
-      </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourcesList">
-            <summary>
-            List all sources available in the running OBS instance
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceTypesList">
-            <summary>
-            List all sources available in the running OBS instance
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceRender(System.String,System.Boolean,System.String)">
-            <summary>
-            Change the visibility of the specified scene item
-            </summary>
-            <param name="itemName">Scene item which visiblity will be changed</param>
-            <param name="visible">Desired visiblity</param>
-            <param name="sceneName">Scene name of the specified item</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemProperties(System.String,System.String)">
-            <summary>
-            Gets the scene specific properties of the specified source item. Coordinates are relative to the item's parent (the scene or group it belongs to).
-            </summary>
-            <param name="itemName">The name of the source</param>
-            <param name="sceneName">The name of the scene that the source item belongs to. Defaults to the current scene.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemPropertiesJson(System.String,System.String)">
-            <summary>
-            Gets the scene specific properties of the specified source item. Coordinates are relative to the item's parent (the scene or group it belongs to).
-            Response is a JObject
-            </summary>
-            <param name="itemName">The name of the source</param>
-            <param name="sceneName">The name of the scene that the source item belongs to. Defaults to the current scene.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTextGDIPlusProperties(System.String)">
-            <summary>
-            Get the current properties of a Text GDI Plus source.
-            </summary>
-            <param name="sourceName">The name of the source</param>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetTBarPosition(System.Double,System.Boolean)">
             <summary>
@@ -874,37 +620,25 @@
             <param name="position">	T-Bar position. This value must be between 0.0 and 1.0.</param>
             <param name="release">Whether or not the T-Bar gets released automatically after setting its new position (like a user releasing their mouse button after moving the T-Bar). Call ReleaseTBar manually if you set release to false. Defaults to true.</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetTextGDIPlusProperties(OBSWebsocketDotNet.Types.TextGDIPlusProperties)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterSettings(System.String,System.String,Newtonsoft.Json.Linq.JObject,System.Boolean)">
             <summary>
-            Set the current properties of a Text GDI Plus source.
+            Apply settings to a source filter
             </summary>
-            <param name="properties">properties for the source</param>
+            <param name="sourceName">Source with filter</param>
+            <param name="filterName">Filter name</param>
+            <param name="filterSettings">JObject with filter settings</param>
+            <param name="overlay">Apply over existing settings?</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.MoveSourceFilter(System.String,System.String,OBSWebsocketDotNet.Types.FilterMovementType)">
-            <summary>
-            Move a filter in the chain (relative positioning)
-            </summary>
-            <param name="sourceName">Scene Name</param>
-            <param name="filterName">Filter Name</param>
-            <param name="movement">Direction to move</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ReorderSourceFilter(System.String,System.String,System.Int32)">
-            <summary>
-            Move a filter in the chain (absolute index positioning)
-            </summary>
-            <param name="sourceName">Scene Name</param>
-            <param name="filterName">Filter Name</param>
-            <param name="newIndex">Desired position of the filter in the chain</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterSettings(System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterSettings(System.String,System.String,OBSWebsocketDotNet.Types.FilterSettings,System.Boolean)">
             <summary>
             Apply settings to a source filter
             </summary>
             <param name="sourceName">Source with filter</param>
             <param name="filterName">Filter name</param>
             <param name="filterSettings">Filter settings</param>
+            <param name="overlay">Apply over existing settings?</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterVisibility(System.String,System.String,System.Boolean)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterEnabled(System.String,System.String,System.Boolean)">
             <summary>
             Modify the Source Filter's visibility
             </summary>
@@ -912,162 +646,144 @@
             <param name="filterName">Source filter name</param>
             <param name="filterEnabled">New filter state</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceFilters(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceFilterList(System.String)">
             <summary>
             Return a list of all filters on a source
             </summary>
             <param name="sourceName">Source name</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceFilterList(System.String)">
-          <summary>
-            Returns a list of all filters assigned to a source (input, scene)
-          </summary>
-          <param name="sourceName">Source name</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceFilterInfo(System.String,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceFilter(System.String,System.String)">
             <summary>
-            Return a list of all filters on a source
+            Return a list of settings for a specific filter
             </summary>
             <param name="sourceName">Source name</param>
             <param name="filterName">Filter name</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ReleaseTBar">
-            <summary>
-            Release the T-Bar (like a user releasing their mouse button after moving it). YOU MUST CALL THIS if you called SetTBarPosition with the release parameter set to false.
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveFilterFromSource(System.String,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveSourceFilter(System.String,System.String)">
             <summary>
             Remove the filter from a source
             </summary>
-            <param name="sourceName"></param>
-            <param name="filterName"></param>
+            <param name="sourceName">Name of the source the filter is on</param>
+            <param name="filterName">Name of the filter to remove</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.AddFilterToSource(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateSourceFilter(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject)">
             <summary>
             Add a filter to a source
             </summary>
             <param name="sourceName">Name of the source for the filter</param>
             <param name="filterName">Name of the filter</param>
-            <param name="filterType">Type of filter</param>
+            <param name="filterKind">Type of filter</param>
+            <param name="filterSettings">JObject holding filter settings object</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateSourceFilter(System.String,System.String,System.String,OBSWebsocketDotNet.Types.FilterSettings)">
+            <summary>
+            Add a filter to a source
+            </summary>
+            <param name="sourceName">Name of the source for the filter</param>
+            <param name="filterName">Name of the filter</param>
+            <param name="filterKind">Type of filter</param>
             <param name="filterSettings">Filter settings object</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleStreaming">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleStream">
             <summary>
-            Start/Stop the streaming output
+            Toggles the status of the stream output.
+            </summary>
+            <returns>New state of the stream output</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleRecord">
+            <summary>
+            Toggles the status of the record output.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleRecording">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStreamStatus">
             <summary>
-            Start/Stop the recording output
+            Gets the status of the stream output
             </summary>
+            <returns>An <see cref="T:OBSWebsocketDotNet.Types.OutputStatus"/> object describing the current outputs states</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStreamingStatus">
-            <summary>
-            Get the current status of the streaming and recording outputs
-            </summary>
-            <returns>An <see cref="T:OBSWebsocketDotNet.OutputStatus"/> object describing the current outputs states</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ListTransitions">
-            <summary>
-            List all transitions
-            </summary>
-            <returns>A <see cref="T:System.Collections.Generic.List`1"/> of all transition names</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentTransition">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentSceneTransition">
             <summary>
             Get the current transition name and duration
             </summary>
             <returns>An <see cref="T:OBSWebsocketDotNet.Types.TransitionSettings"/> object with the current transition name and duration</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentTransition(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentSceneTransition(System.String)">
             <summary>
             Set the current transition to the specified one
             </summary>
             <param name="transitionName">Desired transition name</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetTransitionDuration(System.Int32)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentSceneTransitionDuration(System.Int32)">
             <summary>
             Change the transition's duration
             </summary>
-            <param name="duration">Desired transition duration (in milliseconds)</param>
+            <param name="transitionDuration">Desired transition duration (in milliseconds)</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetTransitionSettings(System.String,Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentSceneTransitionSettings(Newtonsoft.Json.Linq.JObject,System.Boolean)">
             <summary>
             Change the current settings of a transition
             </summary>
-            <param name="transitionName">Transition name</param>
             <param name="transitionSettings">Transition settings (they can be partial)</param>
+            <param name="overlay">Whether to overlay over the current settins or replace them</param>
             <returns>Updated transition settings</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetVolume(System.String,System.Single,System.Boolean)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputVolume(System.String,System.Single,System.Boolean)">
             <summary>
             Change the volume of the specified source
             </summary>
-            <param name="sourceName">Name of the source which volume will be changed</param>
-            <param name="volume">Desired volume. Must be between `0.0` and `1.0` for amplitude/mul (useDecibel is false), and under 0.0 for dB (useDecibel is true). Note: OBS will interpret dB values under -100.0 as Inf.</param>
-            <param name="useDecibel">Interperet `volume` data as decibels instead of amplitude/mul.</param>
+            <param name="inputName">Name of the source which volume will be changed</param>
+            <param name="inputVolume">Desired volume. Must be between `0.0` and `1.0` for amplitude/mul (useDecibel is false), and under 0.0 for dB (useDecibel is true). Note: OBS will interpret dB values under -100.0 as Inf.</param>
+            <param name="inputVolumeDb">Interperet `volume` data as decibels instead of amplitude/mul.</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetVolume(System.String,System.Boolean)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputVolume(System.String)">
             <summary>
             Get the volume of the specified source
             Volume is between `0.0` and `1.0` if using amplitude/mul (useDecibel is false), under `0.0` if using dB (useDecibel is true).
             </summary>
-            <param name="sourceName">Source name</param>
-            <param name="useDecibel">Output volume in decibels of attenuation instead of amplitude/mul.</param>
+            <param name="inputName">Source name</param>
             <returns>An <see cref="T:OBSWebsocketDotNet.Types.VolumeInfo"/>Object containing the volume and mute state of the specified source.</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetMute(System.String,System.Boolean)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputMute(System.String)">
+            <summary>
+            Gets the audio mute state of an input.
+            </summary>
+            <param name="inputName">Name of input to get the mute state of</param>
+            <returns>Whether the input is muted</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputMute(System.String,System.Boolean)">
             <summary>
             Set the mute state of the specified source
             </summary>
-            <param name="sourceName">Name of the source which mute state will be changed</param>
-            <param name="mute">Desired mute state</param>
+            <param name="inputName">Name of the source which mute state will be changed</param>
+            <param name="inputMuted">Desired mute state</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleMute(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleInputMute(System.String)">
             <summary>
             Toggle the mute state of the specified source
             </summary>
-            <param name="sourceName">Name of the source which mute state will be toggled</param>
+            <param name="inputName">Name of the source which mute state will be toggled</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemPosition(System.String,System.Single,System.Single,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemTransform(System.String,System.Int32,Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Set the position of the specified scene item
+            Sets the transform and crop info of a scene item
             </summary>
-            <param name="itemName">Name of the scene item which position will be changed</param>
-            <param name="x">X coordinate</param>
-            <param name="y">Y coordinate</param>
-            <param name="sceneName">(optional) name of the scene the item belongs to</param>
+            <param name="sceneName">Name of the scene that has the SceneItem</param>
+            <param name="sceneItemId">Id of the Scene Item</param>
+            <param name="sceneItemTransform">JObject holding transform settings</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemTransform(System.String,System.Single,System.Single,System.Single,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemTransform(System.String,System.Int32,OBSWebsocketDotNet.Types.SceneItemTransformInfo)">
             <summary>
-            Set the scale and rotation of the specified scene item
+            Sets the transform and crop info of a scene item
             </summary>
-            <param name="itemName">Name of the scene item which transform will be changed</param>
-            <param name="rotation">Rotation in Degrees</param>
-            <param name="xScale">Horizontal scale factor</param>
-            <param name="yScale">Vertical scale factor</param>
-            <param name="sceneName">(optional) name of the scene the item belongs to</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemProperties(OBSWebsocketDotNet.Types.SceneItemProperties,System.String)">
-            <summary>
-            Sets the scene specific properties of a source. Unspecified properties will remain unchanged. Coordinates are relative to the item's parent (the scene or group it belongs to).
-            </summary>
-            <param name="props">Object containing changes</param>
-            <param name="sceneName">Option scene name</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemProperties(Newtonsoft.Json.Linq.JObject,System.String)">
-            <summary>
-            
-            </summary>
-            <param name="obj"></param>
-            <param name="sceneName"></param>
+            <param name="sceneName">Name of the scene that has the SceneItem</param>
+            <param name="sceneItemId">Id of the Scene Item</param>
+            <param name="sceneItemTransform">Transform settings</param>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentSceneCollection(System.String)">
             <summary>
             Set the current scene collection to the specified one
             </summary>
-            <param name="scName">Desired scene collection name</param>
+            <param name="sceneCollectionName">Desired scene collection name</param>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentSceneCollection">
             <summary>
@@ -1075,7 +791,7 @@
             </summary>
             <returns>Name of the current scene collection</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ListSceneCollections">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneCollectionList">
             <summary>
             List all scene collections
             </summary>
@@ -1087,71 +803,50 @@
             </summary>
             <param name="profileName">Name of the desired profile</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentProfile">
-            <summary>
-            Get the name of the current profile
-            </summary>
-            <returns>Name of the current profile</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ListProfiles">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetProfileList">
             <summary>
             List all profiles
             </summary>
             <returns>A <see cref="T:System.Collections.Generic.List`1"/> of the names of all profiles</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartStreaming">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartStream">
             <summary>
             Start streaming. Will trigger an error if streaming is already active
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StopStreaming">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StopStream">
             <summary>
             Stop streaming. Will trigger an error if streaming is not active.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartStopStreaming">
-            <summary>
-            Toggle Streaming
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartRecording">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartRecord">
             <summary>
             Start recording. Will trigger an error if recording is already active.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StopRecording">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StopRecord">
             <summary>
             Stop recording. Will trigger an error if recording is not active.
+            <returns>File name for the saved recording</returns>
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartStopRecording">
-            <summary>
-            Toggle recording
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.PauseRecording">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.PauseRecord">
             <summary>
             Pause the current recording. Returns an error if recording is not active or already paused.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ResumeRecording">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ResumeRecord">
             <summary>
             Resume/unpause the current recording (if paused). Returns an error if recording is not active or not paused.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetRecordingFolder(System.String)">
-            <summary>
-            Change the current recording folder
-            </summary>
-            <param name="recFolder">Recording folder path</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetRecordingFolder">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetRecordDirectory">
             <summary>
             Get the path of the current recording folder
             </summary>
             <returns>Current recording folder path</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetRecordingStatus">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetRecordStatus">
             <summary>
             Get current recording status.
             </summary>
@@ -1163,108 +858,53 @@
             </summary>
             <returns>Current recording status. true when active</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionSettings(System.String)">
-            <summary>
-            Get the current settings of a transition
-            </summary>
-            <param name="transitionName">Transition name</param>
-            <returns>Current transition settings</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionDuration">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneTransitionList">
             <summary>
             Get duration of the currently selected transition (if supported)
             </summary>
             <returns>Current transition duration (in milliseconds)</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionKindList">
-            <summary>
-              Gets an array of all available transition kinds.\n\nSimilar to `GetInputKindList
-            </summary>
-            <returns>Array of all available transition kinds.</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionList">
-            <summary>
-            Get duration of the currently selected transition (if supported)
-            </summary>
-            <returns>Current transition duration (in milliseconds)</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionPosition">
-            <summary>
-            Get the position of the current transition. Value will be between 0.0 and 1.0.
-            Note: Returns 1.0 when not active.
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StudioModeEnabled">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStudioModeEnabled">
             <summary>
             Get status of Studio Mode
             </summary>
             <returns>Studio Mode status (on/off)</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.DisableStudioMode">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetStudioModeEnabled(System.Boolean)">
             <summary>
-            Disable Studio Mode
+            Enables or disables studio mode
             </summary>
+            <param name="studioModeEnabled"></param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.EnableStudioMode">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentPreviewScene">
             <summary>
-            Enable Studio Mode
+            Get the name of the currently selected preview scene. 
+            Note: Triggers an error if Studio Mode is disabled
             </summary>
+            <returns>Preview scene name</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStudioModeStatus">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentPreviewScene(System.String)">
             <summary>
-            Enable Studio Mode
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetStudioMode(System.Boolean)">
-            <summary>
-            Enable/disable Studio Mode
-            </summary>
-            <param name="enable">Desired Studio Mode status</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleStudioMode">
-            <summary>
-            Toggle Studio Mode status (on to off or off to on)
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetPreviewScene">
-            <summary>
-            Get the currently selected preview scene. Triggers an error
-            if Studio Mode is disabled
-            </summary>
-            <returns>Preview scene object</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetPreviewScene(System.String)">
-            <summary>
-            Change the currently active preview scene to the one specified.
+            Change the currently active preview/studio scene to the one specified.
             Triggers an error if Studio Mode is disabled
             </summary>
-            <param name="previewScene">Preview scene name</param>
+            <param name="sceneName">Preview scene name</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetPreviewScene(OBSWebsocketDotNet.Types.OBSScene)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetCurrentPreviewScene(OBSWebsocketDotNet.Types.ObsScene)">
             <summary>
-            Change the currently active preview scene to the one specified.
+            Change the currently active preview/studio scene to the one specified.
             Triggers an error if Studio Mode is disabled.
             </summary>
             <param name="previewScene">Preview scene object</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TransitionToProgram(System.Int32,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TriggerStudioModeTransition">
             <summary>
-            Triggers a Studio Mode transition (preview scene to program)
+            Triggers the current scene transition. Same functionality as the `Transition` button in Studio Mode
             </summary>
-            <param name="transitionDuration">(optional) Transition duration</param>
-            <param name="transitionName">(optional) Name of transition to use</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMute(System.String)">
-            <summary>
-            Get if the specified source is muted
-            </summary>
-            <param name="sourceName">Source name</param>
-            <returns>Source mute status (on/off)</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleReplayBuffer">
             <summary>
-            Toggle the Replay Buffer on/off
+            Toggles the state of the replay buffer output.
             </summary>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartReplayBuffer">
@@ -1280,11 +920,6 @@
             Replay Buffer is not active.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartStopReplayBuffer">
-            <summary>
-            Toggle replay buffer
-            </summary>
-        </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.SaveReplayBuffer">
             <summary>
             Save and flush the contents of the Replay Buffer to disk. Basically
@@ -1292,625 +927,3076 @@
             Triggers an error if Replay Buffer is not active.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSyncOffset(System.String,System.Int32)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputAudioSyncOffset(System.String,System.Int32)">
             <summary>
             Set the audio sync offset of the specified source
             </summary>
-            <param name="sourceName">Source name</param>
-            <param name="syncOffset">Audio offset (in nanoseconds) for the specified source</param>
+            <param name="inputName">Source name</param>
+            <param name="inputAudioSyncOffset">Audio offset (in nanoseconds) for the specified source</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSyncOffset(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputAudioSyncOffset(System.String)">
             <summary>
             Get the audio sync offset of the specified source
             </summary>
-            <param name="sourceName">Source name</param>
+            <param name="inputName">Source name</param>
             <returns>Audio offset (in nanoseconds) of the specified source</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.DeleteSceneItem(OBSWebsocketDotNet.Types.SceneItemStub,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveSceneItem(System.String,System.Int32)">
             <summary>
-            Deletes a scene item
-            </summary>
-            <param name="sceneItem">Scene item, requires name or id of item</param>
-            /// <param name="sceneName">Scene name to delete item from (optional)</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.DeleteSceneItem(System.Int32,System.String)">
-            <summary>
-            Deletes a scene item
+            Removes a scene item from a scene.
+            Scenes only.
             </summary>
             <param name="sceneItemId">Scene item id</param>
-            /// <param name="sceneName">Scene name to delete item from (optional)</param>
+            <param name="sceneName">Scene name from which to delete item</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemCrop(System.String,OBSWebsocketDotNet.Types.SceneItemCropInfo,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SendStreamCaption(System.String)">
             <summary>
-            Set the relative crop coordinates of the specified source item
+            Sends CEA-608 caption text over the stream output. As of OBS Studio 23.1, captions are not yet available on Linux.
             </summary>
-            <param name="sceneItemName">Name of the scene item</param>
-            <param name="cropInfo">Crop coordinates</param>
-            <param name="sceneName">(optional) parent scene name of the specified source</param>
+            <param name="captionText">Captions text</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemCrop(OBSWebsocketDotNet.Types.SceneItem,OBSWebsocketDotNet.Types.SceneItemCropInfo,OBSWebsocketDotNet.Types.OBSScene)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.DuplicateSceneItem(System.String,System.Int32,System.String)">
             <summary>
-            Set the relative crop coordinates of the specified source item
+            Duplicates a scene item
             </summary>
-            <param name="sceneItem">Scene item object</param>
-            <param name="cropInfo">Crop coordinates</param>
-            <param name="scene">Parent scene of scene item</param>
+            <param name="sceneName">Name of the scene that has the SceneItem</param>
+            <param name="sceneItemId">Id of the Scene Item</param>
+            <param name="destinationSceneName">Name of scene to add the new duplicated Scene Item. If not specified will assume sceneName</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ResetSceneItem(System.String,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSpecialInputs">
             <summary>
-            Reset a scene item
+            Gets the names of all special inputs.
             </summary>
-            <param name="itemName">Name of the source item</param>
-            <param name="sceneName">Name of the scene the source belongs to. Defaults to the current scene.</param>
+            <returns>Dictionary of special inputs.</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SendCaptions(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetStreamServiceSettings(OBSWebsocketDotNet.Types.StreamingService)">
             <summary>
-            Send the provided text as embedded CEA-608 caption data. As of OBS Studio 23.1, captions are not yet available on Linux.
+            Sets the current stream service settings (stream destination).
+            Note: Simple RTMP settings can be set with type `rtmp_custom` and the settings fields `server` and `key`.
             </summary>
-            <param name="text">Captions text</param>
+            <param name="service">Stream Service Type Name and Settings objects</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetFilenameFormatting(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStreamServiceSettings">
             <summary>
-            Set the filename formatting string
+            Gets the current stream service settings (stream destination).
             </summary>
-            <param name="filenameFormatting">Filename formatting string to set</param>
+            <returns>Stream service type and settings objects</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.DuplicateSceneItem(System.String,System.String,OBSWebsocketDotNet.Types.SceneItem)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputAudioMonitorType(System.String)">
             <summary>
-            Set the relative crop coordinates of the specified source item
+            Gets the audio monitor type of an input.
+            The available audio monitor types are:
+            - `OBS_MONITORING_TYPE_NONE`
+            - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+            - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
             </summary>
-            <param name="fromSceneName">Source of the scene item</param>
-            <param name="toSceneName">Destination for the scene item</param>
-            <param name="sceneItem">Scene item, requires name or id</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.DuplicateSceneItem(System.String,System.String,System.Int32)">
-            <summary>
-            Set the relative crop coordinates of the specified source item
-            </summary>
-            <param name="fromSceneName">Source of the scene item</param>
-            <param name="toSceneName">Destination for the scene item</param>
-            <param name="sceneItemID">Scene item id to duplicate</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSpecialSources">
-            <summary>
-            Get names of configured special sources (like Desktop Audio
-            and Mic sources)
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetStreamingSettings(OBSWebsocketDotNet.Types.StreamingService,System.Boolean)">
-            <summary>
-            Set current streaming settings
-            </summary>
-            <param name="service">Service settings</param>
-            <param name="save">Save to disk</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetStreamSettings">
-            <summary>
-            Get current streaming settings
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetStreamSettings(OBSWebsocketDotNet.Types.StreamingService,System.Boolean)">
-            <summary>
-            Set current streaming settings
-            </summary>
-            <param name="service">Service settings</param>
-            <param name="save">Save to disk</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SaveStreamSettings">
-            <summary>
-            Save current Streaming settings to disk
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetBrowserSourceProperties(System.String,System.String)">
-            <summary>
-            Get settings of the specified BrowserSource
-            </summary>
-            <param name="sourceName">Source name</param>
-            <param name="sceneName">Optional name of a scene where the specified source can be found</param>
-            <returns>BrowserSource properties</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetBrowserSourceProperties(System.String,OBSWebsocketDotNet.Types.BrowserSourceProperties,System.String)">
-            <summary>
-            Set settings of the specified BrowserSource
-            </summary>
-            <param name="sourceName">Source name</param>
-            <param name="props">BrowserSource properties</param>
-            <param name="sceneName">Optional name of a scene where the specified source can be found</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetHeartbeat(System.Boolean)">
-            <summary>
-            Enable/disable the heartbeat event
-            </summary>
-            <param name="enable"></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceSettings(System.String,System.String)">
-            <summary>
-            Get the settings from a source item
-            </summary>
-            <param name="sourceName">Source name</param>
-            <param name="sourceType">Type of the specified source. Useful for type-checking to avoid settings a set of settings incompatible with the actual source's type.</param>
-            <returns>settings</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceSettings(System.String,Newtonsoft.Json.Linq.JObject,System.String)">
-            <summary>
-            Set settings of the specified source.
-            </summary>
-            <param name="sourceName">Source name</param>
-            <param name="settings">Settings for the source</param>
-            <param name="sourceType">Type of the specified source. Useful for type-checking to avoid settings a set of settings incompatible with the actual source's type.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMediaSourceSettings(System.String)">
-            <summary>
-            Gets settings for a media source
-            </summary>
-            <param name="sourceName"></param>
-            <returns></returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetMediaSourceSettings(OBSWebsocketDotNet.MediaSourceSettings)">
-            <summary>
-            Sets settings of a media source
-            </summary>
-            <param name="sourceSettings"></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OpenProjector(System.String,System.Int32,System.String,System.String)">
-            <summary>
-            Open a projector window or create a projector on a monitor. Requires OBS v24.0.4 or newer.
-            </summary>
-            <param name="projectorType">Type of projector: "Preview" (default), "Source", "Scene", "StudioProgram", or "Multiview" (case insensitive)</param>
-            <param name="monitor">Monitor to open the projector on. If -1 or omitted, opens a window</param>
-            <param name="geometry">Size and position of the projector window (only if monitor is -1). Encoded in Base64 using Qt's geometry encoding. Corresponds to OBS's saved projectors</param>
-            <param name="name">Name of the source or scene to be displayed (ignored for other projector types)</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceName(System.String,System.String)">
-            <summary>
-            Renames a source.
-            Note: If the new name already exists as a source, obs-websocket will return an error.
-            </summary>
-            <param name="currentName">Current source name</param>
-            <param name="newName">New source name</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ListOutputs">
-            <summary>
-            List existing outputs
-            </summary>
-            <returns>Array of OutputInfo</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetAudioActive(System.String)">
-            <summary>
-            Get the audio's active status of a specified source.
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <returns>Audio active status of the source.</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetAudioMonitorType(System.String)">
-            <summary>
-            Get the audio monitoring type of the specified source.
-            Valid return values: none, monitorOnly, monitorAndOutput
-            </summary>
-            <param name="sourceName">Source name</param>
+            <param name="inputName">Source name</param>
             <returns>The monitor type in use</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetAudioMonitorType(System.String,System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputAudioMonitorType(System.String,System.String)">
             <summary>
-            Set the audio monitoring type of the specified source
+            Sets the audio monitor type of an input.
             </summary>
-            <param name="sourceName">Source name</param>
-            <param name="monitorType">The monitor type to use. Options: none, monitorOnly, monitorAndOutput</param>
+            <param name="inputName">Name of the input to set the audio monitor type of</param>
+            <param name="monitorType">Audio monitor type. See `GetInputAudioMonitorType for possible types.</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.BroadcastCustomMessage(System.String,Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.BroadcastCustomEvent(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Broadcast custom message to all connected WebSocket clients
+            Broadcasts a `CustomEvent` to all WebSocket clients. Receivers are clients which are identified and subscribed.
             </summary>
-            <param name="realm">Identifier to be choosen by the client</param>
-            <param name="data">User-defined data</param>
+            <param name="eventData">Data payload to emit to all receivers</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RefreshBrowserSource(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetMediaInputCursor(System.String,System.Int32)">
             <summary>
-            Refreshes the specified browser source.
+            Sets the cursor position of a media input.
+            This request does not perform bounds checking of the cursor position.
             </summary>
-            <param name="sourceName">Source name.</param>
+            <param name="inputName">Name of the media input</param>
+            <param name="mediaCursor">New cursor position to set (milliseconds).</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.PlayPauseMedia(System.String,System.Nullable{System.Boolean})">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OffsetMediaInputCursor(System.String,System.Int32)">
             <summary>
-            Pause or play a media source. Supports ffmpeg and vlc media sources (as of OBS v25.0.8) Note :Leaving out playPause toggles the current pause state
+            Offsets the current cursor position of a media input by the specified value.
+            This request does not perform bounds checking of the cursor position.
             </summary>
-            <param name="sourceName">Source name</param>
-            <param name="playPause">(optional) Whether to pause or play the source. false for play, true for pause.</param>
+            <param name="inputName">Name of the media input</param>
+            <param name="mediaCursorOffset">Value to offset the current cursor position by (milliseconds +/-)</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RestartMedia(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateInput(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,System.Nullable{System.Boolean})">
             <summary>
-            Restart a media source. Supports ffmpeg and vlc media sources (as of OBS v25.0.8)
+            Creates a new input, adding it as a scene item to the specified scene.
             </summary>
-            <param name="sourceName">Source name.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.StopMedia(System.String)">
-            <summary>
-            Stop a media source. Supports ffmpeg and vlc media sources (as of OBS v25.0.8)
-            </summary>
-            <param name="sourceName">Source name.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.NextMedia(System.String)">
-            <summary>
-            Skip to the next media item in the playlist. Supports only vlc media source (as of OBS v25.0.8)
-            </summary>
-            <param name="sourceName">Source name.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.PreviousMedia(System.String)">
-            <summary>
-            Go to the previous media item in the playlist. Supports only vlc media source (as of OBS v25.0.8)
-            </summary>
-            <param name="sourceName">Source name.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMediaDuration(System.String)">
-            <summary>
-            Get the length of media in milliseconds. Supports ffmpeg and vlc media sources (as of OBS v25.0.8) Note: For some reason, for the first 5 or so seconds that the media is playing, the total duration can be off by upwards of 50ms.
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <returns>The total length of media in milliseconds.</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMediaTime(System.String)">
-            <summary>
-            Get the current timestamp of media in milliseconds. Supports ffmpeg and vlc media sources (as of OBS v25.0.8)
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <returns>The time in milliseconds since the start of the media.</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetMediaTime(System.String,System.Int32)">
-            <summary>
-            Set the timestamp of a media source. Supports ffmpeg and vlc media sources (as of OBS v25.0.8)
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <param name="timestamp">Milliseconds to set the timestamp to.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ScrubMedia(System.String,System.Int32)">
-            <summary>
-            Scrub media using a supplied offset. Supports ffmpeg and vlc media sources (as of OBS v25.0.8) Note: Due to processing/network delays, this request is not perfect. The processing rate of this request has also not been tested.
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <param name="timeOffset">Millisecond offset (positive or negative) to offset the current media position.</param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMediaState(System.String)">
-            <summary>
-            Get the current playing state of a media source. Supports ffmpeg and vlc media sources (as of OBS v25.0.8)
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <returns>The media state of the provided source.</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMediaSourcesList">
-            <summary>
-            List the media state of all media sources (vlc and media source)
-            </summary>
-            <returns>Array of sources</returns>
-        </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateSource(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,System.Nullable{System.Boolean})">
-            <summary>
-            Create a source and add it as a sceneitem to a scene.
-            </summary>
-            <param name="sourceName">Source name.</param>
-            <param name="sourceKind">Source kind, Eg. vlc_source</param>
-            <param name="sceneName">Scene to add the new source to.</param>
-            <param name="sourceSettings">Source settings data.</param>
-            <param name="setVisible">Set the created SceneItem as visible or not. Defaults to true</param>
+            <param name="sceneName">Name of the scene to add the input to as a scene item</param>
+            <param name="inputName">Name of the new input to created</param>
+            <param name="inputKind">The kind of input to be created</param>
+            <param name="inputSettings">Jobject holding the settings object to initialize the input with</param>
+            <param name="sceneItemEnabled">Whether to set the created scene item to enabled or disabled</param>
             <returns>ID of the SceneItem in the scene.</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceDefaultSettings(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputDefaultSettings(System.String)">
             <summary>
-            Get the default settings for a given source type.
+            Gets the default settings for an input kind.
             </summary>
-            <param name="sourceKind">Source kind. Also called "source id" in libobs terminology.</param>
-            <returns>Settings object for source.</returns>
+            <param name="inputKind">Input kind to get the default settings for</param>
+            <returns>Object of default settings for the input kind</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemList(System.String)">
             <summary>
-            Get a list of all scene items in a scene.
+            Gets a list of all scene items in a scene.
+            Scenes only
             </summary>
-            <param name="sceneName">Name of the scene to get the list of scene items from. Defaults to the current scene if not specified.</param>
+            <param name="sceneName">Name of the scene to get the items of</param>
+            <returns>Array of scene items in the scene</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.AddSceneItem(System.String,System.String,System.Boolean)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateSceneItem(System.String,System.String,System.Boolean)">
             <summary>
-            Creates a scene item in a scene. In other words, this is how you add a source into a scene.
+            Creates a new scene item using a source.
+            Scenes only
             </summary>
-            <param name="sceneName">Name of the scene to create the scene item in</param>
-            <param name="sourceName">Name of the source to be added</param>
-            <param name="setVisible">Whether to make the scene item visible on creation or not. Default true</param>
-            <returns>Numerical ID of the created scene item</returns>
+            <param name="sceneName">Name of the scene to create the new item in</param>
+            <param name="sourceName">Name of the source to add to the scene</param>
+            <param name="sceneItemEnabled">Enable state to apply to the scene item on creation</param>
+            <returns>Numeric ID of the scene item</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateScene(System.String)">
             <summary>
-            Create a new scene.
+            Creates a new scene in OBS.
             </summary>
-            <param name="sceneName">Name of the scene to create.</param>
+            <param name="sceneName">Name for the new scene</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetAudioTracks(System.String)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputAudioTracks(System.String)">
             <summary>
-            Gets whether an audio track is active for a source.
+            Gets the enable state of all audio tracks of an input.
             </summary>
-            <param name="sourceName">Source name</param>
-            <returns>Indication for each track whther it's active or not</returns>
+            <param name="inputName">Name of the input</param>
+            <returns>Object of audio tracks and associated enable states</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetAudioTrack(System.String,System.Int32,System.Boolean)">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputAudioTracks(System.String,Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Sets whether an audio track is active for a source.
+            Sets the enable state of audio tracks of an input.
             </summary>
-            <param name="sourceName">Source Name</param>
-            <param name="trackNum">Audio tracks 1-6</param>
-            <param name="isActive">Whether audio track is active or not</param>
-            <returns></returns>
+            <param name="inputName">Name of the input</param>
+            <param name="inputAudioTracks">JObject holding track settings to apply</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputAudioTracks(System.String,OBSWebsocketDotNet.Types.SourceTracks)">
+            <summary>
+            Sets the enable state of audio tracks of an input.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="inputAudioTracks">Track settings to apply</param>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceActive(System.String)">
             <summary>
-            Get the source's active status of a specified source (if it is showing in the final mix).
+            Gets the active and show state of a source.
+            **Compatible with inputs and scenes.**
             </summary>
-            <param name="sourceName">Source Name</param>
-            <returns>Active status of the source</returns>
+            <param name="sourceName">Name of the source to get the active state of</param>
+            <returns>Whether the source is showing in Program</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetVirtualCamStatus">
             <summary>
-            Get the current status of the virtual camera
+            Gets the status of the virtualcam output.
             </summary>
-            <returns>An <see cref="T:OBSWebsocketDotNet.VirtualCamStatus"/> object describing the current virtual camera state</returns>
+            <returns>An <see cref="T:OBSWebsocketDotNet.Types.VirtualCamStatus"/> object describing the current virtual camera state</returns>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.StartVirtualCam">
             <summary>
-            Start virtual camera. Will trigger an error if virtual camera is already started.
+            Starts the virtualcam output.
             </summary>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.StopVirtualCam">
             <summary>
-            Stop virtual camera. Will trigger an error if virtual camera is already stopped.
+            Stops the virtualcam output.
             </summary>
         </member>
         <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleVirtualCam">
             <summary>
-            Toggle virtual camera on or off (depending on the current virtual camera state).
+            Toggles the state of the virtualcam output.
+            </summary>
+            <returns>Whether the output is active</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetPersistentData(System.String,System.String)">
+            <summary>
+            Gets the value of a \"slot\" from the selected persistent data realm.
+            </summary>
+            <param name="realm">The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`</param>
+            <param name="slotName">The name of the slot to retrieve data from</param>
+            <returns type="Any">Value associated with the slot. `null` if not set</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetPersistentData(System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Sets the value of a \"slot\" from the selected persistent data realm.
+            </summary>
+            <param name="realm">The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`</param>
+            <param name="slotName">The name of the slot to retrieve data from</param>
+            <param name="slotValue">The value to apply to the slot</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateSceneCollection(System.String)">
+            <summary>
+            Creates a new scene collection, switching to it in the process.\n\nNote: This will block until the collection has finished changing.
+            </summary>
+            <param name="sceneCollectionName">Name for the new scene collection</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CreateProfile(System.String)">
+            <summary>
+            Creates a new profile, switching to it in the process
+            </summary>
+            <param name="profileName">Name for the new profile</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveProfile(System.String)">
+            <summary>
+            Removes a profile. If the current profile is chosen, it will change to a different profile first.
+            </summary>
+            <param name="profileName">Name of the profile to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetProfileParameter(System.String,System.String)">
+            <summary>
+            Gets a parameter from the current profile's configuration.
+            </summary>
+            <param name="parameterCategory">Category of the parameter to get</param>
+            <param name="parameterName">Name of the parameter to get</param>
+            <returns></returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetProfileParameter(System.String,System.String,System.String)">
+            <summary>
+            Sets the value of a parameter in the current profile's configuration.
+            </summary>
+            <param name="parameterCategory">Category of the parameter to set</param>
+            <param name="parameterName">Name of the parameter to set</param>
+            <param name="parameterValue">Value of the parameter to set. Use `null` to delete</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetVideoSettings(OBSWebsocketDotNet.Types.ObsVideoSettings)">
+            <summary>
+            Sets the current video settings.
+            Note: Fields must be specified in pairs. For example, you cannot set only `baseWidth` without needing to specify `baseHeight`.
+            </summary>
+            <param name="obsVideoSettings">Object containing video settings</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceFilterDefaultSettings(System.String)">
+            <summary>
+            Gets the default settings for a filter kind.
+            </summary>
+            <param name="filterKind">Filter kind to get the default settings for</param>
+            <returns>Object of default settings for the filter kind</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterName(System.String,System.String,System.String)">
+            <summary>
+            Sets the name of a source filter (rename).
+            </summary>
+            <param name="sourceName">Name of the source the filter is on</param>
+            <param name="filterName">Current name of the filter</param>
+            <param name="newFilterName">New name for the filter</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSourceFilterIndex(System.String,System.String,System.Int32)">
+            <summary>
+            Sets the index position of a filter on a source.
+            </summary>
+            <param name="sourceName">Name of the source the filter is on</param>
+            <param name="filterName">Name of the filter</param>
+            <param name="filterIndex">New index position of the filter</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetVersion">
+            <summary>
+            Gets data about the current plugin and RPC version.
+            </summary>
+            <returns>Version info in an <see cref="T:OBSWebsocketDotNet.Types.ObsVersion"/> object</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.CallVendorRequest(System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Call a request registered to a vendor.
+            A vendor is a unique name registered by a third-party plugin or script, which allows for custom requests and events to be added to obs-websocket.
+            If a plugin or script implements vendor requests or events, documentation is expected to be provided with them.
+            </summary>
+            <param name="vendorName">Name of the vendor to use</param>
+            <param name="requestType">The request type to call</param>
+            <param name="requestData">Object containing appropriate request data</param>
+            <returns>Object containing appropriate response data. {} if request does not provide any response data</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetHotkeyList">
+            <summary>
+            Gets an array of all hotkey names in OBS
+            </summary>
+            <returns>Array of hotkey names</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.Sleep(System.Int32,System.Int32)">
+            <summary>
+            Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
+            </summary>
+            <param name="sleepMillis">Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)</param>
+            <param name="sleepFrames">Number of frames to sleep for (if `SERIAL_FRAME` mode)</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputList(System.String)">
+            <summary>
+            Gets an array of all inputs in OBS.
+            </summary>
+            <param name="inputKind">Restrict the array to only inputs of the specified kind</param>
+            <returns>List of Inputs in OBS</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputKindList(System.Boolean)">
+            <summary>
+            Gets an array of all available input kinds in OBS.
+            </summary>
+            <param name="unversioned">True == Return all kinds as unversioned, False == Return with version suffixes (if available)</param>
+            <returns>Array of input kinds</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveInput(System.String)">
+            <summary>
+            Removes an existing input.
+            Note: Will immediately remove all associated scene items.
+            </summary>
+            <param name="inputName">Name of the input to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputName(System.String,System.String)">
+            <summary>
+            Sets the name of an input (rename).
+            </summary>
+            <param name="inputName">Current input name</param>
+            <param name="newInputName">New name for the input</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputSettings(System.String)">
+            <summary>
+            Gets the settings of an input.
+            Note: Does not include defaults. To create the entire settings object, overlay `inputSettings` over the `defaultInputSettings` provided by `GetInputDefaultSettings`.
+            </summary>
+            <param name="inputName">Name of the input to get the settings of</param>
+            <returns>New populated InputSettings object</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputSettings(OBSWebsocketDotNet.Types.InputSettings,System.Boolean)">
+            <summary>
+            Sets the settings of an input.
+            </summary>
+            <param name="inputSettings">Object of settings to apply</param>
+            <param name="overlay">True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputSettings(System.String,Newtonsoft.Json.Linq.JObject,System.Boolean)">
+            <summary>
+            Sets the settings of an input.
+            </summary>
+            <param name="inputName">Name of the input to set the settings of</param>
+            <param name="inputSettings">Object of settings to apply</param>
+            <param name="overlay">True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputAudioBalance(System.String)">
+            <summary>
+            Gets the audio balance of an input.
+            </summary>
+            <param name="inputName">Name of the input to get the audio balance of</param>
+            <returns>Audio balance value from 0.0-1.0</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetInputAudioBalance(System.String,System.Double)">
+            <summary>
+            Sets the audio balance of an input.
+            </summary>
+            <param name="inputName">Name of the input to set the audio balance of</param>
+            <param name="inputAudioBalance">New audio balance value</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetInputPropertiesListPropertyItems(System.String,System.String)">
+            <summary>
+            Gets the items of a list property from an input's properties.
+            Note: Use this in cases where an input provides a dynamic, selectable list of items.
+            For example, display capture, where it provides a list of available displays.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="propertyName">Name of the list property to get the items of</param>
+            <returns>Array of items in the list property</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.PressInputPropertiesButton(System.String,System.String)">
+            <summary>
+            Presses a button in the properties of an input.
+            Note: Use this in cases where there is a button in the properties of an input that cannot be accessed in any other way.
+            For example, browser sources, where there is a refresh button.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="propertyName">Name of the button property to press</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMediaInputStatus(System.String)">
+            <summary>
+            Gets the status of a media input.\n\nMedia States:
+            - `OBS_MEDIA_STATE_NONE`
+            - `OBS_MEDIA_STATE_PLAYING`
+            - `OBS_MEDIA_STATE_OPENING`
+            - `OBS_MEDIA_STATE_BUFFERING`
+            - `OBS_MEDIA_STATE_PAUSED`
+            - `OBS_MEDIA_STATE_STOPPED`
+            - `OBS_MEDIA_STATE_ENDED`
+            - `OBS_MEDIA_STATE_ERROR`
+            </summary>
+            <param name="inputName">Name of the media input</param>
+            <returns>Object containing string mediaState, int mediaDuration, int mediaCursor properties</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.TriggerMediaInputAction(System.String,System.String)">
+            <summary>
+            Triggers an action on a media input.
+            </summary>
+            <param name="inputName">Name of the media input</param>
+            <param name="mediaAction">Identifier of the `ObsMediaInputAction` enum</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetLastReplayBufferReplay">
+            <summary>
+            Gets the filename of the last replay buffer save file.
+            </summary>
+            <returns>File path of last replay</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.ToggleRecordPause">
+            <summary>
+            Toggles pause on the record output.
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.OutputStatus">
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetGroupSceneItemList(System.String)">
             <summary>
-            Status of streaming output and recording output
+            Currently BROKEN in obs-websocket/obs-studio
+            Basically GetSceneItemList, but for groups.
+            Using groups at all in OBS is discouraged, as they are very broken under the hood.
+            Groups only
+            </summary>
+            <param name="sceneName">Name of the group to get the items of</param>
+            <returns>Array of scene items in the group</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemId(System.String,System.String,System.Int32)">
+            <summary>
+            Searches a scene for a source, and returns its id.\n\nScenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene or group to search in</param>
+            <param name="sourceName">Name of the source to find</param>
+            <param name="searchOffset">Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item</param>
+            <returns>Numeric ID of the scene item</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemTransform(System.String,System.Int32)">
+            <summary>
+            Gets the transform and crop info of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Object containing scene item transform info</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemTransformRaw(System.String,System.Int32)">
+            <summary>
+            Gets the JObject of transform settings for a scene item. Use this one you don't want it populated with default values.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Object containing scene item transform info</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemEnabled(System.String,System.Int32)">
+            <summary>
+            Gets the enable state of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Whether the scene item is enabled. `true` for enabled, `false` for disabled</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemEnabled(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Gets the enable state of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <param name="sceneItemEnabled">New enable state of the scene item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemLocked(System.String,System.Int32)">
+            <summary>
+            Gets the lock state of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Whether the scene item is locked. `true` for locked, `false` for unlocked</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemLocked(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Sets the lock state of a scene item.
+            Scenes and Group
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <param name="sceneItemLocked">New lock state of the scene item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemIndex(System.String,System.Int32)">
+            <summary>
+            Gets the index position of a scene item in a scene.
+            An index of 0 is at the bottom of the source list in the UI.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Index position of the scene item</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemIndex(System.String,System.Int32,System.Int32)">
+            <summary>
+            Sets the index position of a scene item in a scene.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <param name="sceneItemIndex">New index position of the scene item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneItemBlendMode(System.String,System.Int32)">
+            <summary>
+            Gets the blend mode of a scene item.
+            Blend modes:
+            - `OBS_BLEND_NORMAL`
+            - `OBS_BLEND_ADDITIVE`
+            - `OBS_BLEND_SUBTRACT`
+            - `OBS_BLEND_SCREEN`
+            - `OBS_BLEND_MULTIPLY`
+            - `OBS_BLEND_LIGHTEN`
+            - `OBS_BLEND_DARKEN`
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Current blend mode</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneItemBlendMode(System.String,System.Int32,System.String)">
+            <summary>
+            Sets the blend mode of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName"></param>
+            <param name="sceneItemId"></param>
+            <param name="sceneItemBlendMode"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetGroupList">
+            <summary>
+            Gets an array of all groups in OBS.
+            Groups in OBS are actually scenes, but renamed and modified. In obs-websocket, we treat them as scenes where we can.
+            </summary>
+            <returns>Array of group names</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.RemoveScene(System.String)">
+            <summary>
+            Removes a scene from OBS.
+            </summary>
+            <param name="sceneName">Name of the scene to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.SetSceneName(System.String,System.String)">
+            <summary>
+            Sets the name of a scene (rename).
+            </summary>
+            <param name="sceneName">Name of the scene to be renamed</param>
+            <param name="newSceneName">New name for the scene</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetSourceScreenshot(System.String,System.String,System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Gets a Base64-encoded screenshot of a source.
+            The `imageWidth` and `imageHeight` parameters are treated as \"scale to inner\", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+            If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+            **Compatible with inputs and scenes.**
+            </summary>
+            <param name="sourceName">Name of the source to take a screenshot of</param>
+            <param name="imageFormat">Image compression format to use. Use `GetVersion` to get compatible image formats</param>
+            <param name="imageWidth">Width to scale the screenshot to</param>
+            <param name="imageHeight">Height to scale the screenshot to</param>
+            <param name="imageCompressionQuality">Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use \"default\" (whatever that means, idk)</param>
+            <returns>Base64-encoded screenshot</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionKindList">
+            <summary>
+            Gets an array of all available transition kinds.
+            Similar to `GetInputKindList`
+            </summary>
+            <returns>Array of transition kinds</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetCurrentSceneTransitionCursor">
+            <summary>
+            Gets the cursor position of the current scene transition.
+            Note: `transitionCursor` will return 1.0 when the transition is inactive.
+            </summary>
+            <returns>Cursor position, between 0.0 and 1.0</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OpenInputPropertiesDialog(System.String)">
+            <summary>
+            Opens the properties dialog of an input.
+            </summary>
+            <param name="inputName">Name of the input to open the dialog of</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OpenInputFiltersDialog(System.String)">
+            <summary>
+            Opens the filters dialog of an input.
+            </summary>
+            <param name="inputName">Name of the input to open the dialog of</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OpenInputInteractDialog(System.String)">
+            <summary>
+            Opens the interact dialog of an input.
+            </summary>
+            <param name="inputName">Name of the input to open the dialog of</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.GetMonitorList">
+            <summary>
+            Gets a list of connected monitors and information about them.
+            </summary>
+            <returns>a list of detected monitors with some information</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OpenSourceProjector(System.String,System.String,System.Int32)">
+            <summary>
+            Opens a projector for a source.
+            Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
+            </summary>
+            <param name="sourceName">Name of the source to open a projector for</param>
+            <param name="projectorGeometry">Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with monitorIndex</param>
+            <param name="monitorIndex">Monitor index, use GetMonitorList to obtain index. -1 to open in windowed mode</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.OBSWebsocket.OpenVideoMixProjector(System.String,System.String,System.Int32)">
+            <summary>
+            Opens a projector for a specific output video mix.
+            Note: This request serves to provide feature parity with 4.x. It is very likely to be changed/deprecated in a future release.
+            </summary>
+            <param name="videoMixType">Mix types: OBS_WEBSOCKET_VIDEO_MIX_TYPE_PREVIEW, OBS_WEBSOCKET_VIDEO_MIX_TYPE_PROGRAM, OBS_WEBSOCKET_VIDEO_MIX_TYPE_MULTIVIEW</param>
+            <param name="projectorGeometry">Size/Position data for a windowed projector, in Qt Base64 encoded format. Mutually exclusive with monitorIndex</param>
+            <param name="monitorIndex">Monitor index, use GetMonitorList to obtain index. -1 to open in windowed mode</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.AuthFailureException">
+            <summary>
+            Thrown if authentication fails
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.OutputStatus.IsStreaming">
+        <member name="T:OBSWebsocketDotNet.ErrorResponseException">
             <summary>
-            True if streaming is started and running, false otherwise
+            Thrown when the server responds with an error
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.OutputStatus.IsRecording">
+        <member name="P:OBSWebsocketDotNet.ErrorResponseException.ErrorCode">
             <summary>
-            True if recording is started and running, false otherwise
+            Error Code of exception
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.OutputStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.ErrorResponseException.#ctor(System.String,System.Int32)">
             <summary>
-            Builds the object from the JSON response body
+            Constructor
             </summary>
-            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
+            <param name="message">Exception Message</param>
+            /// <param name="errorCode">Error Code</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.OutputStatus.#ctor">
+        <member name="T:OBSWebsocketDotNet.IOBSWebsocket">
             <summary>
-            Default Constructor for deserialization
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.AudioMixerChannel">
-            <summary>
-            Audio Mixer Channel information
+            OBS Websocket Dotnet interface
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.AudioMixerChannel.Enabled">
+        <member name="P:OBSWebsocketDotNet.IOBSWebsocket.WSTimeout">
             <summary>
-            Is channel enabled
+            WebSocket request timeout, represented as a TimeSpan object
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.AudioMixerChannel.ID">
+        <member name="P:OBSWebsocketDotNet.IOBSWebsocket.IsConnected">
             <summary>
-            ID of the channel
+            Current connection state
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.AudioMixersChangedInfo">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetVideoSettings">
             <summary>
-            Response from audio mixer change event
+            Get basic OBS video information
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.AudioMixersChangedInfo.SourceName">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SaveSourceScreenshot(System.String,System.String,System.String,System.Int32,System.Int32,System.Int32)">
             <summary>
-            Mixer source name
+            Saves a screenshot of a source to the filesystem.
+            The `imageWidth` and `imageHeight` parameters are treated as \"scale to inner\", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+            If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+            **Compatible with inputs and scenes.**
+            </summary>
+            <param name="sourceName">Name of the source to take a screenshot of</param>
+            <param name="imageFormat">Image compression format to use. Use `GetVersion` to get compatible image formats</param>
+            <param name="imageFilePath">Path to save the screenshot file to. Eg. `C:\\Users\\user\\Desktop\\screenshot.png`</param>
+            <param name="imageWidth">Width to scale the screenshot to</param>
+            <param name="imageHeight">Height to scale the screenshot to</param>
+            <param name="imageCompressionQuality">Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use \"default\" (whatever that means, idk)</param>
+            <returns>Base64-encoded screenshot string</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SaveSourceScreenshot(System.String,System.String,System.String)">
+            <summary>
+            Saves a screenshot of a source to the filesystem.
+            The `imageWidth` and `imageHeight` parameters are treated as \"scale to inner\", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+            If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+            **Compatible with inputs and scenes.**
+            </summary>
+            <param name="sourceName">Name of the source to take a screenshot of</param>
+            <param name="imageFormat">Image compression format to use. Use `GetVersion` to get compatible image formats</param>
+            <param name="imageFilePath">Path to save the screenshot file to. Eg. `C:\\Users\\user\\Desktop\\screenshot.png`</param>
+            <returns>Base64-encoded screenshot string</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.TriggerHotkeyByName(System.String)">
+            <summary>
+            Executes hotkey routine, identified by hotkey unique name
+            </summary>
+            <param name="hotkeyName">Unique name of the hotkey, as defined when registering the hotkey (e.g. "ReplayBuffer.Save")</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.TriggerHotkeyByKeySequence(OBSWebsocketDotNet.Types.OBSHotkey,OBSWebsocketDotNet.Types.KeyModifier)">
+            <summary>
+            Triggers a hotkey using a sequence of keys.
+            </summary>
+            <param name="keyId">Main key identifier (e.g. OBS_KEY_A for key "A"). Available identifiers are here: https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hotkeys.h</param>
+            <param name="keyModifier">Optional key modifiers object. You can combine multiple key operators. e.g. KeyModifier.Shift | KeyModifier.Control</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetCurrentProgramScene">
+            <summary>
+            Get the name of the currently active scene. 
+            </summary>
+            <returns>Name of the current scene</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentProgramScene(System.String)">
+            <summary>
+            Set the current scene to the specified one
+            </summary>
+            <param name="sceneName">The desired scene name</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetStats">
+            <summary>
+            Get OBS stats (almost the same info as provided in OBS' stats window)
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.AudioMixersChangedInfo.Mixers">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ListScenes">
             <summary>
-            Routing status of the source for each audio mixer (array of 6 values)
+            List every available scene
+            </summary>
+            <returns>A <see cref="T:System.Collections.Generic.List`1" /> of <see cref="T:OBSWebsocketDotNet.Types.SceneBasicInfo"/> objects describing each scene</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneList">
+            <summary>
+            Get a list of scenes in the currently active profile
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.AudioMixersChangedInfo.HexMixersValue">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneSceneTransitionOverride(System.String)">
             <summary>
-            Raw mixer flags (little-endian, one bit per mixer) as an hexadecimal value
+            Get the specified scene's transition override info
+            </summary>
+            <param name="sceneName">Name of the scene to return the override info</param>
+            <returns>TransitionOverrideInfo</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneSceneTransitionOverride(System.String,System.String,System.Int32)">
+            <summary>
+            Set specific transition override for a scene
+            </summary>
+            <param name="sceneName">Name of the scene to set the transition override</param>
+            <param name="transitionName">Name of the transition to use</param>
+            <param name="transitionDuration">Duration in milliseconds of the transition if transition is not fixed. Defaults to the current duration specified in the UI if there is no current override and this value is not given</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetTBarPosition(System.Double,System.Boolean)">
+            <summary>
+            If your code needs to perform multiple successive T-Bar moves (e.g. : in an animation, or in response to a user moving a T-Bar control in your User Interface), set release to false and call ReleaseTBar later once the animation/interaction is over.
+            </summary>
+            <param name="position">	T-Bar position. This value must be between 0.0 and 1.0.</param>
+            <param name="release">Whether or not the T-Bar gets released automatically after setting its new position (like a user releasing their mouse button after moving the T-Bar). Call ReleaseTBar manually if you set release to false. Defaults to true.</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSourceFilterSettings(System.String,System.String,Newtonsoft.Json.Linq.JObject,System.Boolean)">
+            <summary>
+            Apply settings to a source filter
+            </summary>
+            <param name="sourceName">Source with filter</param>
+            <param name="filterName">Filter name</param>
+            <param name="filterSettings">JObject with filter settings</param>
+            <param name="overlay">Apply over existing settings?</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSourceFilterSettings(System.String,System.String,OBSWebsocketDotNet.Types.FilterSettings,System.Boolean)">
+            <summary>
+            Apply settings to a source filter
+            </summary>
+            <param name="sourceName">Source with filter</param>
+            <param name="filterName">Filter name</param>
+            <param name="filterSettings">Filter settings</param>
+            <param name="overlay">Apply over existing settings?</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSourceFilterEnabled(System.String,System.String,System.Boolean)">
+            <summary>
+            Modify the Source Filter's visibility
+            </summary>
+            <param name="sourceName">Source name</param>
+            <param name="filterName">Source filter name</param>
+            <param name="filterEnabled">New filter state</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSourceFilterList(System.String)">
+            <summary>
+            Return a list of all filters on a source
+            </summary>
+            <param name="sourceName">Source name</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSourceFilter(System.String,System.String)">
+            <summary>
+            Return a list of settings for a specific filter
+            </summary>
+            <param name="sourceName">Source name</param>
+            <param name="filterName">Filter name</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.RemoveSourceFilter(System.String,System.String)">
+            <summary>
+            Remove the filter from a source
+            </summary>
+            <param name="sourceName">Name of the source the filter is on</param>
+            <param name="filterName">Name of the filter to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateSourceFilter(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Add a filter to a source
+            </summary>
+            <param name="sourceName">Name of the source for the filter</param>
+            <param name="filterName">Name of the filter</param>
+            <param name="filterKind">Type of filter</param>
+            <param name="filterSettings">JObject holding filter settings object</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateSourceFilter(System.String,System.String,System.String,OBSWebsocketDotNet.Types.FilterSettings)">
+            <summary>
+            Add a filter to a source
+            </summary>
+            <param name="sourceName">Name of the source for the filter</param>
+            <param name="filterName">Name of the filter</param>
+            <param name="filterKind">Type of filter</param>
+            <param name="filterSettings">Filter settings object</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ToggleStream">
+            <summary>
+            Toggles the status of the stream output.
+            </summary>
+            <returns>New state of the stream output</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ToggleRecord">
+            <summary>
+            Toggles the status of the record output.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.AudioMixersChangedInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetStreamStatus">
             <summary>
-            Create mixer response
+            Gets the status of the stream output
             </summary>
-            <param name="body"></param>
+            <returns>An <see cref="T:OBSWebsocketDotNet.Types.OutputStatus"/> object describing the current outputs states</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.AudioMixersChangedInfo.#ctor">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetCurrentSceneTransition">
             <summary>
-            Default Constructor for deserialization
+            Get the current transition name and duration
             </summary>
+            <returns>An <see cref="T:OBSWebsocketDotNet.Types.TransitionSettings"/> object with the current transition name and duration</returns>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.BrowserSourceProperties">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentSceneTransition(System.String)">
             <summary>
-            BrowserSource source properties
+            Set the current transition to the specified one
             </summary>
+            <param name="transitionName">Desired transition name</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.Source">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentSceneTransitionDuration(System.Int32)">
             <summary>
-            Source name for the browser properties
+            Change the transition's duration
             </summary>
+            <param name="transitionDuration">Desired transition duration (in milliseconds)</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.URL">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentSceneTransitionSettings(Newtonsoft.Json.Linq.JObject,System.Boolean)">
             <summary>
-            URL to load in the embedded browser
+            Change the current settings of a transition
             </summary>
+            <param name="transitionSettings">Transition settings (they can be partial)</param>
+            <param name="overlay">Whether to overlay over the current settins or replace them</param>
+            <returns>Updated transition settings</returns>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.IsLocalFile">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputVolume(System.String,System.Single,System.Boolean)">
             <summary>
-            true if the URL points to a local file, false otherwise.
+            Change the volume of the specified source
             </summary>
+            <param name="inputName">Name of the source which volume will be changed</param>
+            <param name="inputVolume">Desired volume. Must be between `0.0` and `1.0` for amplitude/mul (useDecibel is false), and under 0.0 for dB (useDecibel is true). Note: OBS will interpret dB values under -100.0 as Inf.</param>
+            <param name="inputVolumeDb">Interperet `volume` data as decibels instead of amplitude/mul.</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.LocalFile">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputVolume(System.String)">
             <summary>
-            File to load in embedded browser 
+            Get the volume of the specified source
+            Volume is between `0.0` and `1.0` if using amplitude/mul (useDecibel is false), under `0.0` if using dB (useDecibel is true).
             </summary>
+            <param name="inputName">Source name</param>
+            <returns>An <see cref="T:OBSWebsocketDotNet.Types.VolumeInfo"/>Object containing the volume and mute state of the specified source.</returns>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.CustomCSS">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputMute(System.String)">
             <summary>
-            Additional CSS to apply to the page
+            Gets the audio mute state of an input.
             </summary>
+            <param name="inputName">Name of input to get the mute state of</param>
+            <returns>Whether the input is muted</returns>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.Width">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputMute(System.String,System.Boolean)">
             <summary>
-            Embedded browser render (viewport) width
+            Set the mute state of the specified source
             </summary>
+            <param name="inputName">Name of the source which mute state will be changed</param>
+            <param name="inputMuted">Desired mute state</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.Height">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ToggleInputMute(System.String)">
             <summary>
-            Embedded browser render (viewport) height
+            Toggle the mute state of the specified source
             </summary>
+            <param name="inputName">Name of the source which mute state will be toggled</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.FPS">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneItemTransform(System.String,System.Int32,Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Embedded browser render frames per second
+            Sets the transform and crop info of a scene item
             </summary>
+            <param name="sceneName">Name of the scene that has the SceneItem</param>
+            <param name="sceneItemId">Id of the Scene Item</param>
+            <param name="sceneItemTransform">JObject holding transform settings</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.CustomFPS">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneItemTransform(System.String,System.Int32,OBSWebsocketDotNet.Types.SceneItemTransformInfo)">
             <summary>
-            true if custom FPS is set
+            Sets the transform and crop info of a scene item
             </summary>
+            <param name="sceneName">Name of the scene that has the SceneItem</param>
+            <param name="sceneItemId">Id of the Scene Item</param>
+            <param name="sceneItemTransform">Transform settings</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.ShutdownWhenNotVisible">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentSceneCollection(System.String)">
             <summary>
-            true if source should be disabled (inactive) when not visible, false otherwise
+            Set the current scene collection to the specified one
             </summary>
+            <param name="sceneCollectionName">Desired scene collection name</param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.RestartWhenActive">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetCurrentSceneCollection">
             <summary>
-            true if source should restart the video when visible
+            Get the name of the current scene collection
             </summary>
+            <returns>Name of the current scene collection</returns>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.BrowserSourceProperties.Visible">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneCollectionList">
             <summary>
-            true if source should be visible, false otherwise
+            List all scene collections
             </summary>
+            <returns>A <see cref="T:System.Collections.Generic.List`1"/> of the names of all scene collections</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.BrowserSourceProperties.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentProfile(System.String)">
             <summary>
-            Construct the object from JSON response data
+            Set the current profile to the specified one
             </summary>
-            <param name="props"></param>
+            <param name="profileName">Name of the desired profile</param>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.BrowserSourceProperties.#ctor">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetProfileList">
             <summary>
-            Default Constructor for deserialization
+            List all profiles
             </summary>
+            <returns>A <see cref="T:System.Collections.Generic.List`1"/> of the names of all profiles</returns>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.CommonRTMPStreamingService">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StartStream">
             <summary>
-            Common RTMP settings (predefined streaming services list)
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.CommonRTMPStreamingService.ServiceName">
-            <summary>
-            Streaming provider name
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.CommonRTMPStreamingService.ServerUrl">
-            <summary>
-            Streaming server URL;
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.CommonRTMPStreamingService.StreamKey">
-            <summary>
-            Stream key
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.CommonRTMPStreamingService.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Construct object from data provided by <see cref="P:OBSWebsocketDotNet.Types.StreamingService.Settings"/>
-            </summary>
-            <param name="settings"></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.CommonRTMPStreamingService.#ctor">
-            <summary>
-            Default Constructor for deserialization
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.CustomRTMPStreamingService">
-            <summary>
-            Custom RTMP settings (fully customizable RTMP credentials)
+            Start streaming. Will trigger an error if streaming is already active
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.ServerAddress">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StopStream">
             <summary>
-            RTMP server URL
+            Stop streaming. Will trigger an error if streaming is not active.
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.StreamKey">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StartRecord">
             <summary>
-            RTMP stream key (URL suffix)
+            Start recording. Will trigger an error if recording is already active.
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.UseAuthentication">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StopRecord">
             <summary>
-            Tell OBS' RTMP client to authenticate to the server
+            Stop recording. Will trigger an error if recording is not active.
+            <returns>File name for the saved recording</returns>
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.AuthUsername">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.PauseRecord">
             <summary>
-            Username used if authentication is enabled
+            Pause the current recording. Returns an error if recording is not active or already paused.
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.AuthPassword">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ResumeRecord">
             <summary>
-            Password used if authentication is enabled
+            Resume/unpause the current recording (if paused). Returns an error if recording is not active or not paused.
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetRecordDirectory">
             <summary>
-            Construct object from data provided by <see cref="P:OBSWebsocketDotNet.Types.StreamingService.Settings"/>
+            Get the path of the current recording folder
             </summary>
-            <param name="settings"></param>
+            <returns>Current recording folder path</returns>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.CustomRTMPStreamingService.#ctor">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetRecordStatus">
             <summary>
-            Default Constructor for deserialization
+            Get current recording status.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetReplayBufferStatus">
+            <summary>
+            Get the status of the OBS replay buffer.
+            </summary>
+            <returns>Current recording status. true when active</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneTransitionList">
+            <summary>
+            Get duration of the currently selected transition (if supported)
+            </summary>
+            <returns>Current transition duration (in milliseconds)</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetStudioModeEnabled">
+            <summary>
+            Get status of Studio Mode
+            </summary>
+            <returns>Studio Mode status (on/off)</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetStudioModeEnabled(System.Boolean)">
+            <summary>
+            Enables or disables studio mode
+            </summary>
+            <param name="studioModeEnabled"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetCurrentPreviewScene">
+            <summary>
+            Get the name of the currently selected preview scene. 
+            Note: Triggers an error if Studio Mode is disabled
+            </summary>
+            <returns>Preview scene name</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentPreviewScene(System.String)">
+            <summary>
+            Change the currently active preview/studio scene to the one specified.
+            Triggers an error if Studio Mode is disabled
+            </summary>
+            <param name="sceneName">Preview scene name</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetCurrentPreviewScene(OBSWebsocketDotNet.Types.ObsScene)">
+            <summary>
+            Change the currently active preview/studio scene to the one specified.
+            Triggers an error if Studio Mode is disabled.
+            </summary>
+            <param name="previewScene">Preview scene object</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.TriggerStudioModeTransition">
+            <summary>
+            Triggers the current scene transition. Same functionality as the `Transition` button in Studio Mode
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.FilterMovementType">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ToggleReplayBuffer">
             <summary>
-            Direction to move filters
+            Toggles the state of the replay buffer output.
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.FilterMovementType.UP">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StartReplayBuffer">
             <summary>
-            Up one
+            Start recording into the Replay Buffer. Triggers an error
+            if the Replay Buffer is already active, or if the "Save Replay Buffer"
+            hotkey is not set in OBS' settings
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.FilterMovementType.DOWN">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StopReplayBuffer">
             <summary>
-            Down one
+            Stop recording into the Replay Buffer. Triggers an error if the
+            Replay Buffer is not active.
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.FilterMovementType.TOP">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SaveReplayBuffer">
             <summary>
-            Top of the list
+            Save and flush the contents of the Replay Buffer to disk. Basically
+            the same as triggering the "Save Replay Buffer" hotkey in OBS.
+            Triggers an error if Replay Buffer is not active.
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.FilterMovementType.BOTTOM">
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputAudioSyncOffset(System.String,System.Int32)">
             <summary>
-            Bottom of the list
+            Set the audio sync offset of the specified source
             </summary>
+            <param name="inputName">Source name</param>
+            <param name="inputAudioSyncOffset">Audio offset (in nanoseconds) for the specified source</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputAudioSyncOffset(System.String)">
+            <summary>
+            Get the audio sync offset of the specified source
+            </summary>
+            <param name="inputName">Source name</param>
+            <returns>Audio offset (in nanoseconds) of the specified source</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.RemoveSceneItem(System.String,System.Int32)">
+            <summary>
+            Removes a scene item from a scene.
+            Scenes only.
+            </summary>
+            <param name="sceneItemId">Scene item id</param>
+            <param name="sceneName">Scene name from which to delete item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SendStreamCaption(System.String)">
+            <summary>
+            Sends CEA-608 caption text over the stream output. As of OBS Studio 23.1, captions are not yet available on Linux.
+            </summary>
+            <param name="captionText">Captions text</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.DuplicateSceneItem(System.String,System.Int32,System.String)">
+            <summary>
+            Duplicates a scene item
+            </summary>
+            <param name="sceneName">Name of the scene that has the SceneItem</param>
+            <param name="sceneItemId">Id of the Scene Item</param>
+            <param name="destinationSceneName">Name of scene to add the new duplicated Scene Item. If not specified will assume sceneName</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSpecialInputs">
+            <summary>
+            Gets the names of all special inputs.
+            </summary>
+            <returns>Dictionary of special inputs.</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetStreamServiceSettings(OBSWebsocketDotNet.Types.StreamingService)">
+            <summary>
+            Sets the current stream service settings (stream destination).
+            Note: Simple RTMP settings can be set with type `rtmp_custom` and the settings fields `server` and `key`.
+            </summary>
+            <param name="service">Stream Service Type Name and Settings objects</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetStreamServiceSettings">
+            <summary>
+            Gets the current stream service settings (stream destination).
+            </summary>
+            <returns>Stream service type and settings objects</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputAudioMonitorType(System.String)">
+            <summary>
+            Gets the audio monitor type of an input.
+            The available audio monitor types are:
+            - `OBS_MONITORING_TYPE_NONE`
+            - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+            - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
+            </summary>
+            <param name="inputName">Source name</param>
+            <returns>The monitor type in use</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputAudioMonitorType(System.String,System.String)">
+            <summary>
+            Sets the audio monitor type of an input.
+            </summary>
+            <param name="inputName">Name of the input to set the audio monitor type of</param>
+            <param name="monitorType">Audio monitor type. See `GetInputAudioMonitorType for possible types.</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.BroadcastCustomEvent(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Broadcasts a `CustomEvent` to all WebSocket clients. Receivers are clients which are identified and subscribed.
+            </summary>
+            <param name="eventData">Data payload to emit to all receivers</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetMediaInputCursor(System.String,System.Int32)">
+            <summary>
+            Sets the cursor position of a media input.
+            This request does not perform bounds checking of the cursor position.
+            </summary>
+            <param name="inputName">Name of the media input</param>
+            <param name="mediaCursor">New cursor position to set (milliseconds).</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.OffsetMediaInputCursor(System.String,System.Int32)">
+            <summary>
+            Offsets the current cursor position of a media input by the specified value.
+            This request does not perform bounds checking of the cursor position.
+            </summary>
+            <param name="inputName">Name of the media input</param>
+            <param name="mediaCursorOffset">Value to offset the current cursor position by (milliseconds +/-)</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateInput(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,System.Nullable{System.Boolean})">
+            <summary>
+            Creates a new input, adding it as a scene item to the specified scene.
+            </summary>
+            <param name="sceneName">Name of the scene to add the input to as a scene item</param>
+            <param name="inputName">Name of the new input to created</param>
+            <param name="inputKind">The kind of input to be created</param>
+            <param name="inputSettings">Jobject holding the settings object to initialize the input with</param>
+            <param name="sceneItemEnabled">Whether to set the created scene item to enabled or disabled</param>
+            <returns>ID of the SceneItem in the scene.</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputDefaultSettings(System.String)">
+            <summary>
+            Gets the default settings for an input kind.
+            </summary>
+            <param name="inputKind">Input kind to get the default settings for</param>
+            <returns>Object of default settings for the input kind</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemList(System.String)">
+            <summary>
+            Gets a list of all scene items in a scene.
+            Scenes only
+            </summary>
+            <param name="sceneName">Name of the scene to get the items of</param>
+            <returns>Array of scene items in the scene</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateSceneItem(System.String,System.String,System.Boolean)">
+            <summary>
+            Creates a new scene item using a source.
+            Scenes only
+            </summary>
+            <param name="sceneName">Name of the scene to create the new item in</param>
+            <param name="sourceName">Name of the source to add to the scene</param>
+            <param name="sceneItemEnabled">Enable state to apply to the scene item on creation</param>
+            <returns>Numeric ID of the scene item</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateScene(System.String)">
+            <summary>
+            Creates a new scene in OBS.
+            </summary>
+            <param name="sceneName">Name for the new scene</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputAudioTracks(System.String)">
+            <summary>
+            Gets the enable state of all audio tracks of an input.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <returns>Object of audio tracks and associated enable states</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputAudioTracks(System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Sets the enable state of audio tracks of an input.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="inputAudioTracks">JObject holding track settings to apply</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputAudioTracks(System.String,OBSWebsocketDotNet.Types.SourceTracks)">
+            <summary>
+            Sets the enable state of audio tracks of an input.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="inputAudioTracks">Track settings to apply</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSourceActive(System.String)">
+            <summary>
+            Gets the active and show state of a source.
+            **Compatible with inputs and scenes.**
+            </summary>
+            <param name="sourceName">Name of the source to get the active state of</param>
+            <returns>Whether the source is showing in Program</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetVirtualCamStatus">
+            <summary>
+            Gets the status of the virtualcam output.
+            </summary>
+            <returns>An <see cref="T:OBSWebsocketDotNet.Types.VirtualCamStatus"/> object describing the current virtual camera state</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StartVirtualCam">
+            <summary>
+            Starts the virtualcam output.
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.StopVirtualCam">
+            <summary>
+            Stops the virtualcam output.
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ToggleVirtualCam">
+            <summary>
+            Toggles the state of the virtualcam output.
+            </summary>
+            <returns>Whether the output is active</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetPersistentData(System.String,System.String)">
+            <summary>
+            Gets the value of a \"slot\" from the selected persistent data realm.
+            </summary>
+            <param name="realm">The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`</param>
+            <param name="slotName">The name of the slot to retrieve data from</param>
+            <returns type="Any">Value associated with the slot. `null` if not set</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetPersistentData(System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Sets the value of a \"slot\" from the selected persistent data realm.
+            </summary>
+            <param name="realm">The data realm to select. `OBS_WEBSOCKET_DATA_REALM_GLOBAL` or `OBS_WEBSOCKET_DATA_REALM_PROFILE`</param>
+            <param name="slotName">The name of the slot to retrieve data from</param>
+            <param name="slotValue">The value to apply to the slot</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateSceneCollection(System.String)">
+            <summary>
+            Creates a new scene collection, switching to it in the process.\n\nNote: This will block until the collection has finished changing.
+            </summary>
+            <param name="sceneCollectionName">Name for the new scene collection</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CreateProfile(System.String)">
+            <summary>
+            Creates a new profile, switching to it in the process
+            </summary>
+            <param name="profileName">Name for the new profile</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.RemoveProfile(System.String)">
+            <summary>
+            Removes a profile. If the current profile is chosen, it will change to a different profile first.
+            </summary>
+            <param name="profileName">Name of the profile to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetProfileParameter(System.String,System.String)">
+            <summary>
+            Gets a parameter from the current profile's configuration.
+            </summary>
+            <param name="parameterCategory">Category of the parameter to get</param>
+            <param name="parameterName">Name of the parameter to get</param>
+            <returns></returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetProfileParameter(System.String,System.String,System.String)">
+            <summary>
+            Sets the value of a parameter in the current profile's configuration.
+            </summary>
+            <param name="parameterCategory">Category of the parameter to set</param>
+            <param name="parameterName">Name of the parameter to set</param>
+            <param name="parameterValue">Value of the parameter to set. Use `null` to delete</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetVideoSettings(OBSWebsocketDotNet.Types.ObsVideoSettings)">
+            <summary>
+            Sets the current video settings.
+            Note: Fields must be specified in pairs. For example, you cannot set only `baseWidth` without needing to specify `baseHeight`.
+            </summary>
+            <param name="obsVideoSettings">Object containing video settings</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSourceFilterDefaultSettings(System.String)">
+            <summary>
+            Gets the default settings for a filter kind.
+            </summary>
+            <param name="filterKind">Filter kind to get the default settings for</param>
+            <returns>Object of default settings for the filter kind</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSourceFilterName(System.String,System.String,System.String)">
+            <summary>
+            Sets the name of a source filter (rename).
+            </summary>
+            <param name="sourceName">Name of the source the filter is on</param>
+            <param name="filterName">Current name of the filter</param>
+            <param name="newFilterName">New name for the filter</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSourceFilterIndex(System.String,System.String,System.Int32)">
+            <summary>
+            Sets the index position of a filter on a source.
+            </summary>
+            <param name="sourceName">Name of the source the filter is on</param>
+            <param name="filterName">Name of the filter</param>
+            <param name="filterIndex">New index position of the filter</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetVersion">
+            <summary>
+            Gets data about the current plugin and RPC version.
+            </summary>
+            <returns>Version info in an <see cref="T:OBSWebsocketDotNet.Types.ObsVersion"/> object</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.CallVendorRequest(System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Call a request registered to a vendor.
+            A vendor is a unique name registered by a third-party plugin or script, which allows for custom requests and events to be added to obs-websocket.
+            If a plugin or script implements vendor requests or events, documentation is expected to be provided with them.
+            </summary>
+            <param name="vendorName">Name of the vendor to use</param>
+            <param name="requestType">The request type to call</param>
+            <param name="requestData">Object containing appropriate request data</param>
+            <returns>Object containing appropriate response data. {} if request does not provide any response data</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetHotkeyList">
+            <summary>
+            Gets an array of all hotkey names in OBS
+            </summary>
+            <returns>Array of hotkey names</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.Sleep(System.Int32,System.Int32)">
+            <summary>
+            Sleeps for a time duration or number of frames. Only available in request batches with types `SERIAL_REALTIME` or `SERIAL_FRAME`.
+            </summary>
+            <param name="sleepMillis">Number of milliseconds to sleep for (if `SERIAL_REALTIME` mode)</param>
+            <param name="sleepFrames">Number of frames to sleep for (if `SERIAL_FRAME` mode)</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputList(System.String)">
+            <summary>
+            Gets an array of all inputs in OBS.
+            </summary>
+            <param name="inputKind">Restrict the array to only inputs of the specified kind</param>
+            <returns>List of Inputs in OBS</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputKindList(System.Boolean)">
+            <summary>
+            Gets an array of all available input kinds in OBS.
+            </summary>
+            <param name="unversioned">True == Return all kinds as unversioned, False == Return with version suffixes (if available)</param>
+            <returns>Array of input kinds</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.RemoveInput(System.String)">
+            <summary>
+            Removes an existing input.
+            Note: Will immediately remove all associated scene items.
+            </summary>
+            <param name="inputName">Name of the input to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputName(System.String,System.String)">
+            <summary>
+            Sets the name of an input (rename).
+            </summary>
+            <param name="inputName">Current input name</param>
+            <param name="newInputName">New name for the input</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputSettings(System.String)">
+            <summary>
+            Gets the settings of an input.
+            Note: Does not include defaults. To create the entire settings object, overlay `inputSettings` over the `defaultInputSettings` provided by `GetInputDefaultSettings`.
+            </summary>
+            <param name="inputName">Name of the input to get the settings of</param>
+            <returns>New populated InputSettings object</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputSettings(OBSWebsocketDotNet.Types.InputSettings,System.Boolean)">
+            <summary>
+            Sets the settings of an input.
+            </summary>
+            <param name="inputSettings">Object of settings to apply</param>
+            <param name="overlay">True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputSettings(System.String,Newtonsoft.Json.Linq.JObject,System.Boolean)">
+            <summary>
+            Sets the settings of an input.
+            </summary>
+            <param name="inputName">Name of the input to set the settings of</param>
+            <param name="inputSettings">Object of settings to apply</param>
+            <param name="overlay">True == apply the settings on top of existing ones, False == reset the input to its defaults, then apply settings.</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputAudioBalance(System.String)">
+            <summary>
+            Gets the audio balance of an input.
+            </summary>
+            <param name="inputName">Name of the input to get the audio balance of</param>
+            <returns>Audio balance value from 0.0-1.0</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetInputAudioBalance(System.String,System.Double)">
+            <summary>
+            Sets the audio balance of an input.
+            </summary>
+            <param name="inputName">Name of the input to set the audio balance of</param>
+            <param name="inputAudioBalance">New audio balance value</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetInputPropertiesListPropertyItems(System.String,System.String)">
+            <summary>
+            Gets the items of a list property from an input's properties.
+            Note: Use this in cases where an input provides a dynamic, selectable list of items.
+            For example, display capture, where it provides a list of available displays.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="propertyName">Name of the list property to get the items of</param>
+            <returns>Array of items in the list property</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.PressInputPropertiesButton(System.String,System.String)">
+            <summary>
+            Presses a button in the properties of an input.
+            Note: Use this in cases where there is a button in the properties of an input that cannot be accessed in any other way.
+            For example, browser sources, where there is a refresh button.
+            </summary>
+            <param name="inputName">Name of the input</param>
+            <param name="propertyName">Name of the button property to press</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetMediaInputStatus(System.String)">
+            <summary>
+            Gets the status of a media input.\n\nMedia States:
+            - `OBS_MEDIA_STATE_NONE`
+            - `OBS_MEDIA_STATE_PLAYING`
+            - `OBS_MEDIA_STATE_OPENING`
+            - `OBS_MEDIA_STATE_BUFFERING`
+            - `OBS_MEDIA_STATE_PAUSED`
+            - `OBS_MEDIA_STATE_STOPPED`
+            - `OBS_MEDIA_STATE_ENDED`
+            - `OBS_MEDIA_STATE_ERROR`
+            </summary>
+            <param name="inputName">Name of the media input</param>
+            <returns>Object containing string mediaState, int mediaDuration, int mediaCursor properties</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.TriggerMediaInputAction(System.String,System.String)">
+            <summary>
+            Triggers an action on a media input.
+            </summary>
+            <param name="inputName">Name of the media input</param>
+            <param name="mediaAction">Identifier of the `ObsMediaInputAction` enum</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetLastReplayBufferReplay">
+            <summary>
+            Gets the filename of the last replay buffer save file.
+            </summary>
+            <returns>File path of last replay</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ToggleRecordPause">
+            <summary>
+            Toggles pause on the record output.
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetGroupSceneItemList(System.String)">
+            <summary>
+            Currently BROKEN in obs-websocket/obs-studio
+            Basically GetSceneItemList, but for groups.
+            Using groups at all in OBS is discouraged, as they are very broken under the hood.
+            Groups only
+            </summary>
+            <param name="sceneName">Name of the group to get the items of</param>
+            <returns>Array of scene items in the group</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemId(System.String,System.String,System.Int32)">
+            <summary>
+            Searches a scene for a source, and returns its id.\n\nScenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene or group to search in</param>
+            <param name="sourceName">Name of the source to find</param>
+            <param name="searchOffset">Number of matches to skip during search. >= 0 means first forward. -1 means last (top) item</param>
+            <returns>Numeric ID of the scene item</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemTransform(System.String,System.Int32)">
+            <summary>
+            Gets the transform and crop info of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Object containing scene item transform info</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemTransformRaw(System.String,System.Int32)">
+            <summary>
+            Gets the JObject of transform settings for a scene item. Use this one you don't want it populated with default values.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Object containing scene item transform info</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemEnabled(System.String,System.Int32)">
+            <summary>
+            Gets the enable state of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Whether the scene item is enabled. `true` for enabled, `false` for disabled</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneItemEnabled(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Gets the enable state of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <param name="sceneItemEnabled">New enable state of the scene item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemLocked(System.String,System.Int32)">
+            <summary>
+            Gets the lock state of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Whether the scene item is locked. `true` for locked, `false` for unlocked</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneItemLocked(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Sets the lock state of a scene item.
+            Scenes and Group
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <param name="sceneItemLocked">New lock state of the scene item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemIndex(System.String,System.Int32)">
+            <summary>
+            Gets the index position of a scene item in a scene.
+            An index of 0 is at the bottom of the source list in the UI.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Index position of the scene item</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneItemIndex(System.String,System.Int32,System.Int32)">
+            <summary>
+            Sets the index position of a scene item in a scene.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <param name="sceneItemIndex">New index position of the scene item</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSceneItemBlendMode(System.String,System.Int32)">
+            <summary>
+            Gets the blend mode of a scene item.
+            Blend modes:
+            - `OBS_BLEND_NORMAL`
+            - `OBS_BLEND_ADDITIVE`
+            - `OBS_BLEND_SUBTRACT`
+            - `OBS_BLEND_SCREEN`
+            - `OBS_BLEND_MULTIPLY`
+            - `OBS_BLEND_LIGHTEN`
+            - `OBS_BLEND_DARKEN`
+            Scenes and Groups
+            </summary>
+            <param name="sceneName">Name of the scene the item is in</param>
+            <param name="sceneItemId">Numeric ID of the scene item</param>
+            <returns>Current blend mode</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneItemBlendMode(System.String,System.Int32,System.String)">
+            <summary>
+            Sets the blend mode of a scene item.
+            Scenes and Groups
+            </summary>
+            <param name="sceneName"></param>
+            <param name="sceneItemId"></param>
+            <param name="sceneItemBlendMode"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetGroupList">
+            <summary>
+            Gets an array of all groups in OBS.
+            Groups in OBS are actually scenes, but renamed and modified. In obs-websocket, we treat them as scenes where we can.
+            </summary>
+            <returns>Array of group names</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.RemoveScene(System.String)">
+            <summary>
+            Removes a scene from OBS.
+            </summary>
+            <param name="sceneName">Name of the scene to remove</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SetSceneName(System.String,System.String)">
+            <summary>
+            Sets the name of a scene (rename).
+            </summary>
+            <param name="sceneName">Name of the scene to be renamed</param>
+            <param name="newSceneName">New name for the scene</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetSourceScreenshot(System.String,System.String,System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Gets a Base64-encoded screenshot of a source.
+            The `imageWidth` and `imageHeight` parameters are treated as \"scale to inner\", meaning the smallest ratio will be used and the aspect ratio of the original resolution is kept.
+            If `imageWidth` and `imageHeight` are not specified, the compressed image will use the full resolution of the source.
+            **Compatible with inputs and scenes.**
+            </summary>
+            <param name="sourceName">Name of the source to take a screenshot of</param>
+            <param name="imageFormat">Image compression format to use. Use `GetVersion` to get compatible image formats</param>
+            <param name="imageWidth">Width to scale the screenshot to</param>
+            <param name="imageHeight">Height to scale the screenshot to</param>
+            <param name="imageCompressionQuality">Compression quality to use. 0 for high compression, 100 for uncompressed. -1 to use \"default\" (whatever that means, idk)</param>
+            <returns>Base64-encoded screenshot</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetTransitionKindList">
+            <summary>
+            Gets an array of all available transition kinds.
+            Similar to `GetInputKindList`
+            </summary>
+            <returns>Array of transition kinds</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetCurrentSceneTransitionCursor">
+            <summary>
+            Gets the cursor position of the current scene transition.
+            Note: `transitionCursor` will return 1.0 when the transition is inactive.
+            </summary>
+            <returns>Cursor position, between 0.0 and 1.0</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.OpenInputPropertiesDialog(System.String)">
+            <summary>
+            Opens the properties dialog of an input.
+            </summary>
+            <param name="inputName">Name of the input to open the dialog of</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.OpenInputFiltersDialog(System.String)">
+            <summary>
+            Opens the filters dialog of an input.
+            </summary>
+            <param name="inputName">Name of the input to open the dialog of</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.OpenInputInteractDialog(System.String)">
+            <summary>
+            Opens the interact dialog of an input.
+            </summary>
+            <param name="inputName">Name of the input to open the dialog of</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetMonitorList">
+            <summary>
+            Gets a list of connected monitors and information about them.
+            </summary>
+            <returns>a list of detected monitors with some information</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.Connect(System.String,System.String)">
+            <summary>
+            Connect this instance to the specified URL, and authenticate (if needed) with the specified password.
+            NOTE: Please subscribe to the Connected/Disconnected events (or atlease check the IsConnected property) to determine when the connection is actually fully established
+            </summary>
+            <param name="url">Server URL in standard URL format.</param>
+            <param name="password">Server password</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.ConnectAsync(System.String,System.String)">
+            <summary>
+            Connect this instance to the specified URL, and authenticate (if needed) with the specified password.
+            NOTE: Please subscribe to the Connected/Disconnected events (or atleast check the IsConnected property) to determine when the connection is actually fully established
+            </summary>
+            <param name="url">Server URL in standard URL format.</param>
+            <param name="password">Server password</param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.Disconnect">
+            <summary>
+            Disconnect this instance from the server
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.SendRequest(System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Sends a message to the websocket API with the specified request type and optional parameters
+            </summary>
+            <param name="requestType">obs-websocket request type, must be one specified in the protocol specification</param>
+            <param name="additionalFields">additional JSON fields if required by the request type</param>
+            <returns>The server's JSON response as a JObject</returns>
+        </member>
+        <member name="M:OBSWebsocketDotNet.IOBSWebsocket.GetAuthInfo">
+            <summary>
+            Request authentication data. You don't have to call this manually.
+            </summary>
+            <returns>Authentication data in an <see cref="T:OBSWebsocketDotNet.Communication.OBSAuthInfo"/> object</returns>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentProgramSceneChanged">
+            <summary>
+            The current program scene has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneListChanged">
+            <summary>
+            The list of scenes has changed.
+            TODO: Make OBS fire this event when scenes are reordered.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemListReindexed">
+            <summary>
+            Triggered when the scene item list of the specified scene is reordered
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemCreated">
+            <summary>
+            Triggered when a new item is added to the item list of the specified scene
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemRemoved">
+            <summary>
+            Triggered when an item is removed from the item list of the specified scene
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemEnableStateChanged">
+            <summary>
+            Triggered when the visibility of a scene item changes
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemLockStateChanged">
+            <summary>
+            Triggered when the lock status of a scene item changes
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentSceneCollectionChanged">
+            <summary>
+            Triggered when switching to another scene collection
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneCollectionListChanged">
+            <summary>
+            Triggered when a scene collection is created, deleted or renamed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentSceneTransitionChanged">
+            <summary>
+            Triggered when switching to another transition
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentSceneTransitionDurationChanged">
+            <summary>
+            Triggered when the current transition duration is changed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneTransitionStarted">
+            <summary>
+            Triggered when a transition between two scenes starts. Followed by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProgramSceneChanged"/>
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneTransitionEnded">
+            <summary>
+            Triggered when a transition (other than "cut") has ended. Please note that the from-scene field is not available in TransitionEnd
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneTransitionVideoEnded">
+            <summary>
+            Triggered when a stinger transition has finished playing its video
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentProfileChanged">
+            <summary>
+            Triggered when switching to another profile
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.ProfileListChanged">
+            <summary>
+            Triggered when a profile is created, imported, removed or renamed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.StreamStateChanged">
+            <summary>
+            Triggered when the streaming output state changes
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.RecordStateChanged">
+            <summary>
+            Triggered when the recording output state changes
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.ReplayBufferStateChanged">
+            <summary>
+            Triggered when state of the replay buffer changes
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentPreviewSceneChanged">
+            <summary>
+            Triggered when the preview scene selection changes (Studio Mode only)
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.StudioModeStateChanged">
+            <summary>
+            Triggered when Studio Mode is turned on or off
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.ExitStarted">
+            <summary>
+            Triggered when OBS exits
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.Connected">
+            <summary>
+            Triggered when connected successfully to an obs-websocket server
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.Disconnected">
+            <summary>
+            Triggered when disconnected from an obs-websocket server
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemSelected">
+            <summary>
+            A scene item is selected in the UI
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneItemTransformChanged">
+            <summary>
+            A scene item transform has changed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputAudioSyncOffsetChanged">
+            <summary>
+            The audio sync offset of an input has changed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SourceFilterCreated">
+            <summary>
+            A filter was added to a source
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SourceFilterRemoved">
+            <summary>
+            A filter was removed from a source
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SourceFilterListReindexed">
+            <summary>
+            Filters in a source have been reordered
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SourceFilterEnableStateChanged">
+            <summary>
+            Triggered when the visibility of a filter has changed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputMuteStateChanged">
+            <summary>
+            A source has been muted or unmuted
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputVolumeChanged">
+            <summary>
+            The volume of a source has changed
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.VendorEvent">
+            <summary>
+            A custom broadcast message was received
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.MediaInputPlaybackEnded">
+            <summary>
+            These events are emitted by the OBS sources themselves. For example when the media file ends. The behavior depends on the type of media source being used.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.MediaInputPlaybackStarted">
+            <summary>
+            These events are emitted by the OBS sources themselves. For example when the media file starts playing. The behavior depends on the type of media source being used.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.MediaInputActionTriggered">
+            <summary>
+            This event is only emitted when something actively controls the media/VLC source. In other words, the source will never emit this on its own naturally.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.VirtualcamStateChanged">
+            <summary>
+            The virtual cam state has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentSceneCollectionChanging">
+            <summary>
+            The current scene collection has begun changing.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.CurrentProfileChanging">
+            <summary>
+            The current profile has begun changing.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SourceFilterNameChanged">
+            <summary>
+            The name of a source filter has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputCreated">
+            <summary>
+            An input has been created.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputRemoved">
+            <summary>
+            An input has been removed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputNameChanged">
+            <summary>
+            The name of an input has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputActiveStateChanged">
+            <summary>
+            An input's active state has changed.
+            When an input is active, it means it's being shown by the program feed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputShowStateChanged">
+            <summary>
+            An input's show state has changed.
+            When an input is showing, it means it's being shown by the preview or a dialog.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputAudioBalanceChanged">
+            <summary>
+            The audio balance value of an input has changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputAudioTracksChanged">
+            <summary>
+            The audio tracks of an input have changed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputAudioMonitorTypeChanged">
+            <summary>
+            The monitor type of an input has changed.
+            Available types are:
+            - `OBS_MONITORING_TYPE_NONE`
+            - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+            - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.InputVolumeMeters">
+            <summary>
+            A high-volume event providing volume levels of all active inputs every 50 milliseconds.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.ReplayBufferSaved">
+            <summary>
+            The replay buffer has been saved.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneCreated">
+            <summary>
+            A new scene has been created.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneRemoved">
+            <summary>
+            A scene has been removed.
+            </summary>
+        </member>
+        <member name="E:OBSWebsocketDotNet.IOBSWebsocket.SceneNameChanged">
+            <summary>
+            The name of a scene has changed.
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentPreviewSceneChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentPreviewSceneChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentPreviewSceneChangedEventArgs.SceneName">
+            <summary>
+            Name of the scene that was switched to
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentPreviewSceneChangedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentProfileChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProfileChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentProfileChangedEventArgs.ProfileName">
+            <summary>
+            Name of the new profile
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentProfileChangedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="profileName">The profile name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentProfileChangingEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProfileChanging"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentProfileChangingEventArgs.ProfileName">
+            <summary>
+            Name of the current profile
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentProfileChangingEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="profileName">The profile name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentSceneCollectionChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneCollectionChanged"/> 
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentSceneCollectionChangedEventArgs.SceneCollectionName">
+            <summary>
+            Name of the new scene collection
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentSceneCollectionChangedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneCollectionName">The scene collection name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentSceneCollectionChangingEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneCollectionChanging"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentSceneCollectionChangingEventArgs.SceneCollectionName">
+            <summary>
+            Name of the current scene collection
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentSceneCollectionChangingEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneCollectionName">The scene collection name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentSceneTransitionChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneTransitionChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentSceneTransitionChangedEventArgs.TransitionName">
+            <summary>
+            Name of the new transition
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentSceneTransitionChangedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="transitionName">The transition name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.CurrentSceneTransitionDurationChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentSceneTransitionDurationChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.CurrentSceneTransitionDurationChangedEventArgs.TransitionDuration">
+            <summary>
+            Transition duration in milliseconds
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.CurrentSceneTransitionDurationChangedEventArgs.#ctor(System.Int32)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="transitionDuration">The transition duration</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputActiveStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputActiveStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputActiveStateChangedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputActiveStateChangedEventArgs.VideoActive">
+            <summary>
+            Whether the input is active
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputActiveStateChangedEventArgs.#ctor(System.String,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="videoActive">Is the video active</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputAudioBalanceChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioBalanceChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioBalanceChangedEventArgs.InputName">
+            <summary>
+            Name of the affected input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioBalanceChangedEventArgs.InputAudioBalance">
+            <summary>
+            New audio balance value of the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputAudioBalanceChangedEventArgs.#ctor(System.String,System.Double)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="inputAudioBalance">The input audio balance</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputAudioMonitorTypeChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioMonitorTypeChanged"/>
+            Available types are:
+            - `OBS_MONITORING_TYPE_NONE`
+            - `OBS_MONITORING_TYPE_MONITOR_ONLY`
+            - `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT`
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioMonitorTypeChangedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioMonitorTypeChangedEventArgs.MonitorType">
+            <summary>
+            New monitor type of the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputAudioMonitorTypeChangedEventArgs.#ctor(System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="monitorType">The monitor type</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputAudioSyncOffsetChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioSyncOffsetChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioSyncOffsetChangedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioSyncOffsetChangedEventArgs.InputAudioSyncOffset">
+            <summary>
+            New sync offset in milliseconds
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputAudioSyncOffsetChangedEventArgs.#ctor(System.String,System.Int32)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="inputAudioSyncOffset">The input audio sync offset</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputAudioTracksChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputAudioTracksChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioTracksChangedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputAudioTracksChangedEventArgs.InputAudioTracks">
+            <summary>
+            Object of audio tracks along with their associated enable states
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputAudioTracksChangedEventArgs.#ctor(System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="inputAudioTracks">The audio track data as a JObject</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputCreated"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs.InputKind">
+            <summary>
+            The kind of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs.UnversionedInputKind">
+            <summary>
+            The unversioned kind of input (aka no `_v2` stuff)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs.InputSettings">
+            <summary>
+            The settings configured to the input when it was created
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs.DefaultInputSettings">
+            <summary>
+            The default settings for the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputCreatedEventArgs.#ctor(System.String,System.String,System.String,Newtonsoft.Json.Linq.JObject,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="inputKind">The kind of input</param>
+            <param name="unversionedInputKind">The unversioned kind of input</param>
+            <param name="inputSettings">The input settings as a JObject</param>
+            <param name="defaultInputSettings">The default input settings as a JObject</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputMuteStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputMuteStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputMuteStateChangedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputMuteStateChangedEventArgs.InputMuted">
+            <summary>
+            Whether the input is muted
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputMuteStateChangedEventArgs.#ctor(System.String,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="inputMuted">Is the input muted</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputNameChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputNameChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputNameChangedEventArgs.OldInputName">
+            <summary>
+            Old name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputNameChangedEventArgs.InputName">
+            <summary>
+            New name of the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputNameChangedEventArgs.#ctor(System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="oldInputName">The old input name</param>
+            <param name="inputName">The new input name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputRemovedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputRemoved"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputRemovedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputRemovedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputShowStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputShowStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputShowStateChangedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputShowStateChangedEventArgs.VideoShowing">
+            <summary>
+            Whether the input is showing
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputShowStateChangedEventArgs.#ctor(System.String,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="videoShowing">Is the video showing</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputVolumeChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputVolumeChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputVolumeChangedEventArgs.Volume">
+            <summary>
+            Current volume levels of source
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputVolumeChangedEventArgs.#ctor(OBSWebsocketDotNet.Types.InputVolume)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="volume">The new input volume</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.InputVolumeMetersEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.InputVolumeMeters"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.InputVolumeMetersEventArgs.inputs">
+            <summary>
+            Array of active inputs with their associated volume levels
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.InputVolumeMetersEventArgs.#ctor(System.Collections.Generic.List{Newtonsoft.Json.Linq.JObject})">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputs">Collection inputs as JObjects</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.MediaInputActionTriggeredEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaInputActionTriggered"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.MediaInputActionTriggeredEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.MediaInputActionTriggeredEventArgs.MediaAction">
+            <summary>
+            Action performed on the input. See `ObsMediaInputAction` enum
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.MediaInputActionTriggeredEventArgs.#ctor(System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+            <param name="mediaAction">The media action data</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.MediaInputPlaybackEndedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaInputPlaybackEnded"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.MediaInputPlaybackEndedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.MediaInputPlaybackEndedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.MediaInputPlaybackStartedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.MediaInputPlaybackStarted"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.MediaInputPlaybackStartedEventArgs.InputName">
+            <summary>
+            Name of the input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.MediaInputPlaybackStartedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="inputName">The input name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.ProfileListChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.ProfileListChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.ProfileListChangedEventArgs.Profiles">
+            <summary>
+            The profiles that have changed
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.ProfileListChangedEventArgs.#ctor(System.Collections.Generic.List{System.String})">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="profiles">Collection of profile names as strings</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.ProgramSceneChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.CurrentProgramSceneChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.ProgramSceneChangedEventArgs.SceneName">
+            <summary>
+            The new scene name
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.ProgramSceneChangedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.RecordStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.RecordStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.RecordStateChangedEventArgs.OutputState">
+            <summary>
+            The specific state of the output
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.RecordStateChangedEventArgs.#ctor(OBSWebsocketDotNet.Types.RecordStateChanged)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="outputState">The record state change data</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.ReplayBufferSavedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.ReplayBufferSaved"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.ReplayBufferSavedEventArgs.SavedReplayPath">
+            <summary>
+            Path of the saved replay file
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.ReplayBufferSavedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="savedReplayPath">The saved replay path</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.ReplayBufferStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.ReplayBufferStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.ReplayBufferStateChangedEventArgs.OutputState">
+            <summary>
+            The specific state of the output
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.ReplayBufferStateChangedEventArgs.#ctor(OBSWebsocketDotNet.Types.OutputStateChanged)">
+            <summary>
+            Default constructor
+            </summary>
+            <param name="outputState">Specific state of the output</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneCollectionListChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneCollectionListChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneCollectionListChangedEventArgs.SceneCollections">
+            <summary>
+            Updated list of scene collections
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneCollectionListChangedEventArgs.#ctor(System.Collections.Generic.List{System.String})">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneCollections">Collection of scene collection names as string</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneCreatedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneCreated"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneCreatedEventArgs.SceneName">
+            <summary>
+            Name of the new scene
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneCreatedEventArgs.IsGroup">
+            <summary>
+            Whether the new scene is a group
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneCreatedEventArgs.#ctor(System.String,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="isGroup">Is the scene item a group</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemCreatedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemCreated"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemCreatedEventArgs.SceneName">
+            <summary>
+            Name of the scene where the item is
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemCreatedEventArgs.SourceName">
+            <summary>
+            Name of the concerned item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemCreatedEventArgs.SceneItemId">
+            <summary>
+            Numeric ID of the scene item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemCreatedEventArgs.SceneItemIndex">
+            <summary>
+            Index position of the item
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemCreatedEventArgs.#ctor(System.String,System.String,System.Int32,System.Int32)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sourceName">The source name</param>
+            <param name="sceneItemId">The scene item id</param>
+            <param name="sceneItemIndex">The scene item index</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemEnableStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemEnableStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemEnableStateChangedEventArgs.SceneName">
+            <summary>
+            Name of the scene the item is in
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemEnableStateChangedEventArgs.SceneItemId">
+            <summary>
+            Numeric ID of the scene item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemEnableStateChangedEventArgs.SceneItemEnabled">
+            <summary>
+            Whether the scene item is enabled (visible)
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemEnableStateChangedEventArgs.#ctor(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sceneItemId">The scene item id</param>
+            <param name="sceneItemEnabled">Is the scene item enabled</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemListReindexedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemListReindexed"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemListReindexedEventArgs.SceneName">
+            <summary>
+            Name of the scene where items where reordered
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemListReindexedEventArgs.SceneItems">
+            <summary>
+            List of all scene items as JObject
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemListReindexedEventArgs.#ctor(System.String,System.Collections.Generic.List{Newtonsoft.Json.Linq.JObject})">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sceneItems">The scene item data as a colleciton of JObjects</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemLockStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemLockStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemLockStateChangedEventArgs.SceneName">
+            <summary>
+            Name of the scene the item is in
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemLockStateChangedEventArgs.SceneItemId">
+            <summary>
+            Numeric ID of the scene item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemLockStateChangedEventArgs.SceneItemLocked">
+            <summary>
+            Whether the scene item is locked (visible)
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemLockStateChangedEventArgs.#ctor(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sceneItemId">The scene item id</param>
+            <param name="sceneItemLocked">is the scene item locked</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemRemovedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemRemoved"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemRemovedEventArgs.SceneName">
+            <summary>
+            Name of the scene where the item was removed from
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemRemovedEventArgs.SourceName">
+            <summary>
+            Name of the concerned item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemRemovedEventArgs.SceneItemId">
+            <summary>
+            Numeric ID of the scene item
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemRemovedEventArgs.#ctor(System.String,System.String,System.Int32)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sourceName">The source name</param>
+            <param name="sceneItemId">The scene items id</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemSelectedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemSelected"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemSelectedEventArgs.SceneName">
+            <summary>
+            Name of the scene item is in
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemSelectedEventArgs.SceneItemId">
+            <summary>
+            Numeric ID of the scene item
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemSelectedEventArgs.#ctor(System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sceneItemId">The scene item id</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneItemTransformEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneItemTransformChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemTransformEventArgs.SceneName">
+            <summary>
+            Name of the scene item is in
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemTransformEventArgs.SceneItemId">
+            <summary>
+            Numeric ID of the scene item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneItemTransformEventArgs.Transform">
+            <summary>
+            Transform data
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneItemTransformEventArgs.#ctor(System.String,System.String,OBSWebsocketDotNet.Types.SceneItemTransformInfo)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="sceneItemId">The scene item id</param>
+            <param name="transform">The transform data</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneListChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneListChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneListChangedEventArgs.Scenes">
+            <summary>
+            Updated array of scenes
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneListChangedEventArgs.#ctor(System.Collections.Generic.List{Newtonsoft.Json.Linq.JObject})">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="scenes">Collection of scene data as JObjects</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneNameChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneNameChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneNameChangedEventArgs.OldSceneName">
+            <summary>
+            Old name of the scene
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneNameChangedEventArgs.SceneName">
+            <summary>
+            New name of the scene
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneNameChangedEventArgs.#ctor(System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="oldSceneName">The previous scene name</param>
+            <param name="sceneName">The new scene name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneRemovedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneRemoved"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneRemovedEventArgs.SceneName">
+            <summary>
+            Name of the removed scene
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneRemovedEventArgs.IsGroup">
+            <summary>
+            Whether the removed scene was a group
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneRemovedEventArgs.#ctor(System.String,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sceneName">The scene name</param>
+            <param name="isGroup">Is the scene name a group</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneTransitionEndedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneTransitionEnded"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneTransitionEndedEventArgs.TransitionName">
+            <summary>
+            Scene transition name
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneTransitionEndedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="transitionName">The transition name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneTransitionStartedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneTransitionStarted"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneTransitionStartedEventArgs.TransitionName">
+            <summary>
+            Transition name
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneTransitionStartedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="transitionName">The transition name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SceneTransitionVideoEndedEventArgs">
+            <summary>
+            Called by <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SceneTransitionVideoEnded"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SceneTransitionVideoEndedEventArgs.TransitionName">
+            <summary>
+            Transition name
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SceneTransitionVideoEndedEventArgs.#ctor(System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="transitionName">The transition name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterCreated"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.SourceName">
+            <summary>
+            Name of the source the filter was added to
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.FilterName">
+            <summary>
+            Name of the filter
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.FilterKind">
+            <summary>
+            The kind of the filter
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.FilterIndex">
+            <summary>
+            Index position of the filter
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.FilterSettings">
+            <summary>
+            The settings configured to the filter when it was created
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.DefaultFilterSettings">
+            <summary>
+            The default settings for the filter
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SourceFilterCreatedEventArgs.#ctor(System.String,System.String,System.String,System.Int32,Newtonsoft.Json.Linq.JObject,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sourceName">The source name</param>
+            <param name="filterName">The filter name</param>
+            <param name="filterKind">The kind of filter</param>
+            <param name="filterIndex">The index of the filter</param>
+            <param name="filterSettings">The filters settings as a JObject</param>
+            <param name="defaultFilterSettings">The default filter settings as a JObject</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SourceFilterEnableStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterEnableStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterEnableStateChangedEventArgs.SourceName">
+            <summary>
+            Name of the source the filter is on
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterEnableStateChangedEventArgs.FilterName">
+            <summary>
+            Name of the filter
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterEnableStateChangedEventArgs.FilterEnabled">
+            <summary>
+            Whether the filter is enabled
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SourceFilterEnableStateChangedEventArgs.#ctor(System.String,System.String,System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sourceName">The source name</param>
+            <param name="filterName">The filter name</param>
+            <param name="filterEnabled">If the filter is enabled or not</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SourceFilterListReindexedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterListReindexed"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterListReindexedEventArgs.SourceName">
+            <summary>
+            Name of the source
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterListReindexedEventArgs.Filters">
+            <summary>
+            Array of filter objects
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SourceFilterListReindexedEventArgs.#ctor(System.String,System.Collections.Generic.List{OBSWebsocketDotNet.Types.FilterReorderItem})">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sourceName">The source name</param>
+            <param name="filters">Collection of filters</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SourceFilterNameChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterNameChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterNameChangedEventArgs.SourceName">
+            <summary>
+            The source the filter is on
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterNameChangedEventArgs.OldFilterName">
+            <summary>
+            Old name of the filter
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterNameChangedEventArgs.FilterName">
+            <summary>
+            New name of the filter
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SourceFilterNameChangedEventArgs.#ctor(System.String,System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sourceName">The source name</param>
+            <param name="oldFilterName">The filters previous name</param>
+            <param name="filterName">The filters new name</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.SourceFilterRemovedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.SourceFilterRemoved"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterRemovedEventArgs.SourceName">
+            <summary>
+            Name of the source the filter was on
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.SourceFilterRemovedEventArgs.FilterName">
+            <summary>
+            Name of the filter
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.SourceFilterRemovedEventArgs.#ctor(System.String,System.String)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="sourceName">The source name</param>
+            <param name="filterName">The filter name that's been removed</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.StreamStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.StreamStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.StreamStateChangedEventArgs.OutputState">
+            <summary>
+            The specific state of the output
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.StreamStateChangedEventArgs.#ctor(OBSWebsocketDotNet.Types.OutputStateChanged)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="outputState">The output state data</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.StudioModeStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.StudioModeStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.StudioModeStateChangedEventArgs.StudioModeEnabled">
+            <summary>
+            New Studio Mode status
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.StudioModeStateChangedEventArgs.#ctor(System.Boolean)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="studioModeEnabled">Is studio mode enabled</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.UnsupportedEventArgs">
+            <summary>
+            Event args for unsupported events
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.UnsupportedEventArgs.EventType">
+            <summary>
+            The type of the event
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.UnsupportedEventArgs.Body">
+            <summary>
+            The body of the event
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.UnsupportedEventArgs.#ctor(System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Event args for unsupported events
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.VendorEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.VendorEvent"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.VendorEventArgs.VendorName">
+            <summary>
+            Name of the vendor emitting the event
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.VendorEventArgs.EventType">
+            <summary>
+            Vendor-provided event typedef
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.VendorEventArgs.eventData">
+            <summary>
+            Vendor-provided event data. {} if event does not provide any data
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.VendorEventArgs.#ctor(System.String,System.String,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="vendorName">The vendor name</param>
+            <param name="eventType">The event type</param>
+            <param name="eventData">The event data as a Json Object</param>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Events.VirtualcamStateChangedEventArgs">
+            <summary>
+            Event args for <see cref="E:OBSWebsocketDotNet.OBSWebsocket.VirtualcamStateChanged"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Events.VirtualcamStateChangedEventArgs.OutputState">
+            <summary>
+            The specific state of the output
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Events.VirtualcamStateChangedEventArgs.#ctor(OBSWebsocketDotNet.Types.OutputStateChanged)">
+            <summary>
+            Default Constructor
+            </summary>
+            <param name="outputState">The output state data</param>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.FilterReorderItem">
             <summary>
@@ -1937,9 +4023,14 @@
             Name of the filter
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.FilterSettings.Type">
+        <member name="P:OBSWebsocketDotNet.Types.FilterSettings.Kind">
             <summary>
             Type of the specified filter
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.FilterSettings.Index">
+            <summary>
+            Index of the filter in the list, beginning at 0
             </summary>
         </member>
         <member name="P:OBSWebsocketDotNet.Types.FilterSettings.IsEnabled">
@@ -1952,14 +4043,35 @@
             Settings for the filter
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.GetSceneListInfo">
+        <member name="T:OBSWebsocketDotNet.Types.GetProfileListInfo">
             <summary>
-            Get Scene Info response
+            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.GetProfileList"/>
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.GetSceneListInfo.CurrentScene">
+        <member name="P:OBSWebsocketDotNet.Types.GetProfileListInfo.CurrentProfileName">
             <summary>
-            Name of the currently active scene
+            Name of the currently active profile
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.GetProfileListInfo.Profiles">
+            <summary>
+            List of all profiles
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.GetSceneListInfo">
+            <summary>
+            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneList"/>
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.GetSceneListInfo.CurrentProgramSceneName">
+            <summary>
+            Name of the currently active program scene
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.GetSceneListInfo.CurrentPreviewSceneName">
+            <summary>
+            Name of the currently active preview/studio scene
+            Note: Will return null if not in studio mode
             </summary>
         </member>
         <member name="P:OBSWebsocketDotNet.Types.GetSceneListInfo.Scenes">
@@ -1967,14 +4079,9 @@
             Ordered list of the current profile's scenes
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.GetTransitionKindListInfo">
-          <summary>
-            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionKindList"/>
-          </summary>
-        </member>
         <member name="T:OBSWebsocketDotNet.Types.GetTransitionListInfo">
             <summary>
-            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.GetTransitionList"/>
+            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneTransitionList"/>
             </summary>
         </member>
         <member name="P:OBSWebsocketDotNet.Types.GetTransitionListInfo.CurrentTransition">
@@ -1982,85 +4089,261 @@
             Name of the currently active transition
             </summary>
         </member>
+        <member name="P:OBSWebsocketDotNet.Types.GetTransitionListInfo.CurrentTransitionKing">
+            <summary>
+            Kind of the currently active transition
+            </summary>
+        </member>
         <member name="P:OBSWebsocketDotNet.Types.GetTransitionListInfo.Transitions">
             <summary>
             List of transitions.
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.Heartbeat">
+        <member name="T:OBSWebsocketDotNet.Types.Input">
             <summary>
-            Heartbeat response
+            Abstract class with information on a specific Input
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.Pulse">
+        <member name="P:OBSWebsocketDotNet.Types.Input.InputName">
             <summary>
-            Toggles between every JSON message as an "I am alive" indicator.
+            Name of the Input
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.CurrentProfile">
+        <member name="P:OBSWebsocketDotNet.Types.Input.InputKind">
             <summary>
-            Current active profile.
+            Kind of the Input
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.CurrentScene">
+        <member name="M:OBSWebsocketDotNet.Types.Input.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Current active scene.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.Streaming">
-            <summary>
-            Current streaming state.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.totalStreamTime">
-            <summary>
-            Total time (in seconds) since the stream started.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.TotalStreamBytes">
-            <summary>
-            Total bytes sent since the stream started.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.TotalStreamFrames">
-            <summary>
-            Total frames streamed since the stream started.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.Recording">
-            <summary>
-            Current recording state.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.TotalRecordTime">
-            <summary>
-            Total time (in seconds) since recording started.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.TotalTecordBytes">
-            <summary>
-            Total bytes recorded since the recording started.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.TotalRecordFrames">
-            <summary>
-            Total frames recorded since the recording started.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.Heartbeat.Stats">
-            <summary>
-            OBS Stats
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.Heartbeat.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Create a heartbeat
+            Instantiate object from response data
             </summary>
             <param name="body"></param>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.Heartbeat.#ctor">
+        <member name="M:OBSWebsocketDotNet.Types.Input.#ctor">
+            <summary>
+            Default Constructor
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.InputBasicInfo">
+            <summary>
+            Input class which also shows the Unversioned Input Kind
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBasicInfo.UnversionedKind">
+            <summary>
+            Unversioned Kind of the Input
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputBasicInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Instantiate object from response data
+            </summary>
+            <param name="body"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputBasicInfo.#ctor">
+            <summary>
+            Default Constructor
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.InputBrowserSourceSettings">
+            <summary>
+            Input class dedicated for the ffmpeg_source input kind.
+            Usage: InputBrowserSourceSettings.FromInputSettings(InputSettings)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.CustomFPS">
+            <summary>
+            Set a custom FPS (using the FPS property)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.FPS">
+            <summary>
+            Frames Per Second
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.RerouteAudio">
+            <summary>
+            Control audio via OBS
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.Height">
+            <summary>
+            Height
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.Width">
+            <summary>
+            Width
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.CSS">
+            <summary>
+            Custom CSS
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.IsLocalFile">
+            <summary>
+            Is Local file
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.LocalFile">
+            <summary>
+            Local filename (when IsLocalFile is true)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.URL">
+            <summary>
+            URL (when IsLocalFile is false)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.RestartWhenActive">
+            <summary>
+            Refresh browser when scene becomes active
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.ShutdownWhenNotVisible">
+            <summary>
+            Shutdown source when not visible
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.ControlLevel">
+            <summary>
+            Page Permissions
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputBrowserSourceSettings.FromInputSettings(OBSWebsocketDotNet.Types.InputSettings)">
+            <summary>
+            Static constructor to instanciate a InputBrowserSourceSettings object
+            Requires an InputSettings class with InputKind of browser_source to create
+            </summary>
+            <param name="settings">Settings object</param>
+            <returns></returns>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.InputFFMpegSettings">
+            <summary>
+            Input class dedicated for the ffmpeg_source input kind.
+            Usage: InputFFMpegSettings.FromInputSettings(InputSettings)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.BufferingMB">
+            <summary>
+            Buffering MB
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.ClearOnMediaEnd">
+            <summary>
+            Clear window when media ends
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.CloseWhenInactive">
+            <summary>
+            Close when inactive
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.ColorRange">
+            <summary>
+            Color Range
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.HWDecode">
+            <summary>
+            HW Decoder
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.IsLocalFile">
+            <summary>
+            Is Local file
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.LocalFile">
+            <summary>
+            Local filename
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.Looping">
+            <summary>
+            Looping
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.LinearAlpha">
+            <summary>
+            Apply alpha in linear space
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.RestartOnActivate">
+            <summary>
+            Restart when activated
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.Options">
+            <summary>
+            ffmpeg options
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputFFMpegSettings.SpeedPercent">
+            <summary>
+            Speed percentage
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputFFMpegSettings.FromInputSettings(OBSWebsocketDotNet.Types.InputSettings)">
+            <summary>
+            Static constructor to instanciate a InputFFMpegSettings object
+            Requires an InputSettings class with InputKind of ffmpeg_source to create
+            </summary>
+            <param name="settings">Setings object</param>
+            <returns></returns>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.InputSettings">
+            <summary>
+            Settings for a source item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputSettings.Settings">
+            <summary>
+            Settings for the source
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputSettings.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Builds the object from the JSON data
+            </summary>
+            <param name="data">JSON item description as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputSettings.#ctor">
             <summary>
             Default Constructor for deserialization
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.InputVolume">
+            <summary>
+            Source volume values
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputVolume.InputName">
+            <summary>
+            Name of the source
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputVolume.InputVolumeMul">
+            <summary>
+            The source volume in percent
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.InputVolume.InputVolumeDb">
+            <summary>
+            The source volume in decibels
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputVolume.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Builds the object from the JSON response body
+            </summary>
+            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.InputVolume.#ctor">
+            <summary>
+            Empty constructor for jsonconvert
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.KeyModifier">
@@ -2093,71 +4376,131 @@
             Command (Mac) / WinKey (?) Windows
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.MediaSource">
+        <member name="T:OBSWebsocketDotNet.Types.MediaInputStatus">
             <summary>
-            Meta Data on the selected media source
+            Status of a Media Input
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.MediaSource.SourceName">
+        <member name="P:OBSWebsocketDotNet.Types.MediaInputStatus.StateString">
             <summary>
-            Name of the source
+            State of the media input
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.MediaSource.SourceKind">
+        <member name="P:OBSWebsocketDotNet.Types.MediaInputStatus.State">
             <summary>
-            Kind of source (a.k.a ffmpeg_source or vlc_source)
+            State of the media input
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.MediaSource.MediaState">
+        <member name="P:OBSWebsocketDotNet.Types.MediaInputStatus.Duration">
             <summary>
-            Type of the specified source. Useful for type-checking if you expect a specific settings schema.
+            Total duration of the playing media in milliseconds. `null` if not playing
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.MediaSource.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="P:OBSWebsocketDotNet.Types.MediaInputStatus.Cursor">
             <summary>
-            Builds the object from the JSON data
+            Position of the cursor in milliseconds. `null` if not playing
             </summary>
-            <param name="data">JSON item description as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.MediaSource.#ctor">
+        <member name="M:OBSWebsocketDotNet.Types.MediaInputStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Default Constructor for deserialization
+            Instantiate from JObject
+            </summary>
+            <param name="body"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.MediaInputStatus.#ctor">
+            <summary>
+            Default Constructor
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.MediaState">
             <summary>
-            The media state.
+            Enum representing the state of a media input
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSAuthInfo">
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_NONE">
             <summary>
-            Data required by authentication
+            No media is loaded
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSAuthInfo.AuthRequired">
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_PLAYING">
             <summary>
-            True if authentication is required, false otherwise
+            Media is playing
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSAuthInfo.Challenge">
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_OPENING">
             <summary>
-            Authentication challenge
+            Media is opening
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSAuthInfo.PasswordSalt">
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_BUFFERING">
             <summary>
-            Password salt
+            Media is buffering
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.OBSAuthInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_PAUSED">
             <summary>
-            Builds the object from JSON response body
+            Media is playing but is paused
             </summary>
-            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.OBSAuthInfo.#ctor">
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_STOPPED">
             <summary>
-            Default Constructor for deserialization
+            Media is stopped
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_ENDED">
+            <summary>
+            Media is ended
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.MediaState.OBS_MEDIA_STATE_ERROR">
+            <summary>
+            Media has errored
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.Monitor">
+            <summary>
+            Information on a connected Monitor
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Monitor.Height">
+            <summary>
+            Monitor height (px)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Monitor.Width">
+            <summary>
+            Monitor width (px)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Monitor.Name">
+            <summary>
+            Monitor Name
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Monitor.Index">
+            <summary>
+            Monitor Index
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Monitor.PositionX">
+            <summary>
+            Monitor Position X
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.Monitor.PositionY">
+            <summary>
+            Monitor Position Y
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Monitor.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Constructor to auto populate
+            </summary>
+            <param name="data"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.Monitor.#ctor">
+            <summary>
+            Default Constructor
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.OBSHotkey">
@@ -2165,266 +4508,181 @@
             OBS Hotkeys as defined here: https://github.com/obsproject/obs-studio/blob/master/libobs/obs-hotkeys.h
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSOutputFlags">
-            <summary>
-            OBS Output flags
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputFlags.RawValue">
-            <summary>
-            Raw flags value
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputFlags.IsAudio">
-            <summary>
-            Output uses audio
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputFlags.IsVideo">
-            <summary>
-            Output uses video
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputFlags.IsEncoded">
-            <summary>
-            Output is encoded
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputFlags.IsMultiTrack">
-            <summary>
-            Output uses several tracks
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputFlags.IsService">
-            <summary>
-            Output users a service
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSOutputInfo">
-            <summary>
-            OBS Output information
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Name">
-            <summary>
-            Output Name
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Type">
-            <summary>
-            Output type/kind
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Height">
-            <summary>
-            Video output height
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Width">
-            <summary>
-            Video output width
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Settings">
-            <summary>
-            Settings
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.IsActive">
-            <summary>
-            Output status (active or not)
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.IsReconnecting">
-            <summary>
-            Output reconnection status (reconnecting or not)
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Congestion">
-            <summary>
-            Output congestion
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.TotalFrames">
-            <summary>
-            Number of frames sent
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.DroppedFrames">
-            <summary>
-            Number of frames dropped
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.TotalBytes">
-            <summary>
-            Total bytes sent
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSOutputInfo.Flags">
-            <summary>
-            Output flags
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSScene">
+        <member name="T:OBSWebsocketDotNet.Types.ObsScene">
             <summary>
             Describes a scene in OBS, along with its items
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSScene.Name">
+        <member name="F:OBSWebsocketDotNet.Types.ObsScene.Name">
             <summary>
             OBS Scene name
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OBSScene.Items">
+        <member name="F:OBSWebsocketDotNet.Types.ObsScene.IsGroup">
+            <summary>
+            Is group
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.ObsScene.Items">
             <summary>
             Scene item list
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.OBSScene.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="M:OBSWebsocketDotNet.Types.ObsScene.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
             Builds the object from the JSON description
             </summary>
             <param name="data">JSON scene description as a <see cref="T:Newtonsoft.Json.Linq.JObject" /></param>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.OBSScene.#ctor">
+        <member name="M:OBSWebsocketDotNet.Types.ObsScene.#ctor">
             <summary>
             Default Constructor for deserialization
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSStats">
+        <member name="T:OBSWebsocketDotNet.Types.ObsStats">
             <summary>
             OBS Stats
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.FPS">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.FPS">
             <summary>
             Current framerate.
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.RenderTotalFrames">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.RenderTotalFrames">
             <summary>
             Number of frames rendered
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.RenderMissedFrames">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.RenderMissedFrames">
             <summary>
             Number of frames missed due to rendering lag
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.OutputTotalFrames">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.OutputTotalFrames">
             <summary>
             Number of frames outputted
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.OutputSkippedFrames">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.OutputSkippedFrames">
             <summary>
             Number of frames skipped due to encoding lag
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.AverageFrameTime">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.AverageFrameTime">
             <summary>
             Average frame render time (in milliseconds)
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.CpuUsage">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.CpuUsage">
             <summary>
             Current CPU usage (percentage)
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.MemoryUsage">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.MemoryUsage">
             <summary>
             Current RAM usage (in megabytes)
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSStats.FreeDiskSpace">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.FreeDiskSpace">
             <summary>
             Free recording disk space (in megabytes)
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSVersion">
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.SessionIncomingMessages">
+            <summary>
+            Total number of messages received by obs-websocket from the client
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.ObsStats.SessionOutgoingMessages">
+            <summary>
+            Total number of messages sent by obs-websocket to the client
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.ObsVersion">
             <summary>
             Version info of the plugin, the API and OBS Studio
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVersion.PluginVersion">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.PluginVersion">
             <summary>
             obs-websocket plugin version
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVersion.OBSStudioVersion">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.OBSStudioVersion">
             <summary>
             OBS Studio version
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVersion.Version">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.Version">
             <summary>
             OBSRemote compatible API version.Fixed to 1.1 for retrocompatibility.
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVersion.AvailableRequests">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.AvailableRequests">
             <summary>
             List of available request types, formatted as a comma-separated list string (e.g. : "Method1,Method2,Method3").
             </summary>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.OBSVersion.#ctor(Newtonsoft.Json.Linq.JObject)">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.SupportedImageFormats">
+            <summary>
+            Image formats available in `GetSourceScreenshot` and `SaveSourceScreenshot` requests.
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.Platform">
+            <summary>
+            Name of the platform. Usually `windows`, `macos`, or `ubuntu` (linux flavor). Not guaranteed to be any of those
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.ObsVersion.PlatformDescription">
+            <summary>
+            Description of the platform, like `Windows 10 (10.0)`
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.ObsVersion.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
             Builds the object from the JSON response body
             </summary>
             <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
         </member>
-        <member name="M:OBSWebsocketDotNet.Types.OBSVersion.#ctor">
+        <member name="M:OBSWebsocketDotNet.Types.ObsVersion.#ctor">
             <summary>
             Empty constructor for jsonconvert
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.OBSVideoInfo">
+        <member name="T:OBSWebsocketDotNet.Types.ObsVideoSettings">
             <summary>
             Basic OBS video information
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.BaseWidth">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVideoSettings.FpsNumerator">
+            <summary>
+            Numerator of the fractional FPS value
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.ObsVideoSettings.FpsDenominator">
+            <summary>
+            Denominator of the fractional FPS value
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.ObsVideoSettings.BaseWidth">
             <summary>
             Base (canvas) width
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.BaseHeight">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVideoSettings.BaseHeight">
             <summary>
             Base (canvas) height
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.OutputWidth">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVideoSettings.OutputWidth">
             <summary>
-            Output width
+            Width of the output resolution in pixels
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.OutputHeight">
+        <member name="P:OBSWebsocketDotNet.Types.ObsVideoSettings.OutputHeight">
             <summary>
-            Output height
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.ScaleType">
-            <summary>
-            Scaling method used if output size differs from base size
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.FPS">
-            <summary>
-            Frames rendered per second
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.VideoFormat">
-            <summary>
-            Video color format
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.ColorSpace">
-            <summary>
-            Color space for YUV
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.OBSVideoInfo.ColorRange">
-            <summary>
-            Color range (full or partial)
+            Height of the output resolution in pixels
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.OutputState">
@@ -2432,24 +4690,121 @@
             Describes the state of an output (streaming or recording)
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OutputState.Starting">
+        <member name="F:OBSWebsocketDotNet.Types.OutputState.OBS_WEBSOCKET_OUTPUT_STARTING">
             <summary>
-            The output is initializing and doesn't produces frames yet
+            The output is initializing and doesn't produce frames yet
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OutputState.Started">
+        <member name="F:OBSWebsocketDotNet.Types.OutputState.OBS_WEBSOCKET_OUTPUT_STARTED">
             <summary>
             The output is running and produces frames
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OutputState.Stopping">
+        <member name="F:OBSWebsocketDotNet.Types.OutputState.OBS_WEBSOCKET_OUTPUT_STOPPING">
             <summary>
             The output is stopping and sends the last remaining frames in its buffer
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.OutputState.Stopped">
+        <member name="F:OBSWebsocketDotNet.Types.OutputState.OBS_WEBSOCKET_OUTPUT_STOPPED">
             <summary>
             The output is completely stopped
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.OutputState.OBS_WEBSOCKET_OUTPUT_PAUSED">
+            <summary>
+            The output is paused (usually recording output)
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.OutputState.OBS_WEBSOCKET_OUTPUT_RESUMED">
+            <summary>
+            The output is resumed (i.e. no longer paused) - usually recording output
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.OutputStateChanged">
+            <summary>
+            Data when Stream/Recording/Instant_Replay change states
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStateChanged.IsActive">
+            <summary>
+            Is output currently active (streaming/recording)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStateChanged.StateStr">
+            <summary>
+            Output state as string
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStateChanged.State">
+            <summary>
+            OutputState enum of current state
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.OutputStateChanged.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Constructor
+            </summary>
+            <param name="body"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.OutputStateChanged.#ctor">
+            <summary>
+            Default Constructor for deserialization
+            </summary>
+        </member>
+        <member name="T:OBSWebsocketDotNet.Types.OutputStatus">
+            <summary>
+            Status of streaming output
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.OutputStatus.IsActive">
+            <summary>
+            True if streaming is started and running, false otherwise
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.IsReconnecting">
+            <summary>
+            Whether the output is currently reconnectins
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.TimeCode">
+            <summary>
+            Current formatted timecode string for the output
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.Duration">
+            <summary>
+            Current duration in milliseconds for the output
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.Congestion">
+            <summary>
+            Congestion of the output
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.BytesSent">
+            <summary>
+            Nubmer of bytes sent by the output
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.SkippedFrames">
+            <summary>
+            Number of frames skipped by the output's process
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.OutputStatus.TotalFrames">
+            <summary>
+            Total number of frames delivered by the output's process
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.OutputStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Builds the object from the JSON response body
+            </summary>
+            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.OutputStatus.#ctor">
+            <summary>
+            Default Constructor for deserialization
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.RecordingStatus">
@@ -2469,123 +4824,64 @@
         </member>
         <member name="P:OBSWebsocketDotNet.Types.RecordingStatus.RecordTimecode">
             <summary>
-            Time elapsed since recording started (only present if currently recording). (Optional)
+            Current formatted timecode string for the output
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.RecordingStatus.RecordingFilename">
+        <member name="P:OBSWebsocketDotNet.Types.RecordingStatus.RecordingDuration">
             <summary>
-            Absolute path to the recording file (only present if currently recording). (Optional)
+            Current duration in milliseconds for the output
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItem">
+        <member name="P:OBSWebsocketDotNet.Types.RecordingStatus.RecordingBytes">
             <summary>
-            Describes a scene item in an OBS scene
+            Number of bytes sent by the output
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.SourceName">
+        <member name="M:OBSWebsocketDotNet.Types.RecordingStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Source name
+            Builds the object from the JSON response body
             </summary>
+            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.InternalType">
-            <summary>
-            Source type. Value is one of the following: "input", "filter", "transition", "scene" or "unknown"
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.AudioVolume">
-            <summary>
-            Source audio volume
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.XPos">
-            <summary>
-            Scene item horizontal position/offset
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.YPos">
-            <summary>
-            Scene item vertical position/offset
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.SourceWidth">
-            <summary>
-            Item source width, without scaling and transforms applied
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.SourceHeight">
-            <summary>
-            Item source height, without scaling and transforms applied
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.Width">
-            <summary>
-            Item width
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItem.Height">
-            <summary>
-            Item height
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItem.Locked">
-            <summary>
-            Whether or not this Scene Item is locked and can't be moved around
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItem.Render">
-            <summary>
-            Whether or not this Scene Item is set to "visible".
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItem.ID">
-            <summary>
-            Scene item ID
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItem.ParentGroupName">
-            <summary>
-            Name of the item's parent (if this item belongs to a group)
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItem.GroupChildren">
-            <summary>
-            Name of the item's parent (if this item belongs to a group)
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SceneItem.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Builds the object from the JSON scene description
-            </summary>
-            <param name="data">JSON item description as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SceneItem.#ctor">
+        <member name="M:OBSWebsocketDotNet.Types.RecordingStatus.#ctor">
             <summary>
             Default Constructor for deserialization
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItemBoundsInfo">
+        <member name="T:OBSWebsocketDotNet.Types.RecordStateChanged">
             <summary>
-            Information on scene item bounds
+            Data when Recording change states
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemBoundsInfo.Alignnment">
+        <member name="P:OBSWebsocketDotNet.Types.RecordStateChanged.OutputPath">
             <summary>
-            Alignment of the bounding box
+            File name for the saved recording, if record stopped. null otherwise
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemBoundsInfo.Type">
+        <member name="M:OBSWebsocketDotNet.Types.RecordStateChanged.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Type of bounding box
+            Constructor
+            </summary>
+            <param name="body"></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.RecordStateChanged.#ctor">
+            <summary>
+            Default Constructor for deserialization
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemBoundsInfo.Width">
+        <member name="T:OBSWebsocketDotNet.Types.SceneBasicInfo">
             <summary>
-            Width of the bounding box
+            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.GetSceneList"/>
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemBoundsInfo.Height">
+        <member name="P:OBSWebsocketDotNet.Types.SceneBasicInfo.Name">
             <summary>
-            Height of the bounding box
+            Name of scene
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneBasicInfo.Index">
+            <summary>
+            Index of scene
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.SceneItemBoundsType">
@@ -2628,31 +4924,6 @@
             No bounds
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItemCropInfo">
-            <summary>
-            Crop coordinates for a scene item
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemCropInfo.Top">
-            <summary>
-            Top crop (in pixels)
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemCropInfo.Bottom">
-            <summary>
-            Bottom crop (in pixels)
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemCropInfo.Left">
-            <summary>
-            Left crop (in pixels)
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemCropInfo.Right">
-            <summary>
-            Right crop (in pixels)
-            </summary>
-        </member>
         <member name="T:OBSWebsocketDotNet.Types.SceneItemDetails">
             <summary>
             Meta data regarding a Scene item
@@ -2689,180 +4960,124 @@
             Default Constructor for deserialization
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItemPointInfo">
-            <summary>
-            Scene item point information
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemPointInfo.X">
-            <summary>
-            The x-scale factor of the scene item
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemPointInfo.Y">
-            <summary>
-            The y-scale factor of the scene item
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItemPositionInfo">
-            <summary>
-            Scene item position information
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemPositionInfo.Alignment">
-            <summary>
-            The point on the scene item that the item is manipulated from
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemPositionInfo.X">
-            <summary>
-            The x position of the scene item from the left
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemPositionInfo.Y">
-            <summary>
-            The y position of the scene item from the top
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItemProperties">
-             <summary>
-            
-             </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Crop">
-            <summary>
-            Crop Information
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Bounds">
-            <summary>
-            Bounds Information
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Scale">
-            <summary>
-            Scale Information
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Position">
-            <summary>
-            Position of the item
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.ItemName">
-            <summary>
-            Scene item name, <i>populated from GetSceneItemProperites only</i>
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Item">
-            <summary>
-            Scene item name, <i>populated from GetSceneItemProperites only</i>
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Height">
-            <summary>
-            Scene item height (base source height multiplied by the vertical scaling factor)
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Width">
-            <summary>
-            Scene item width (base source width multiplied by the horizontal scaling factor)
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Locked">
-            <summary>
-            If the scene item is locked in position
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Visible">
-            <summary>
-            If the scene item is visible
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.SourceHeight">
-            <summary>
-            Base height (without scaling) of the source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.SourceWidth">
-            <summary>
-            Base width (without scaling) of the source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemProperties.Rotation">
-            <summary>
-            The clockwise rotation of the scene item in degrees around the point of alignment.
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SceneItemProperties.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Initialize the scene item transform
-            </summary>
-            <param name="body"></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SceneItemProperties.#ctor">
-            <summary>
-            Default Constructor for deserialization
-            </summary>
-        </member>
         <member name="T:OBSWebsocketDotNet.Types.SceneItemSourceType">
             <summary>
             Type of scene item's source
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.Input">
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.OBS_SOURCE_TYPE_INPUT">
             <summary>
             Input
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.Group">
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.OBS_SOURCE_TYPE_FILTER">
             <summary>
-            Group
+            Filter
             </summary>
         </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.Scene">
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.OBS_SOURCE_TYPE_TRANSITION">
+            <summary>
+            Transition
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemSourceType.OBS_SOURCE_TYPE_SCENE">
             <summary>
             Scene
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SceneItemStub">
-            <summary>
-            Stub for scene item that only contains the name or ID of an item
-            </summary>
-        </member>
-        <member name="F:OBSWebsocketDotNet.Types.SceneItemStub.SourceName">
-            <summary>
-            Source name
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemStub.ID">
-            <summary>
-            Scene item ID
-            </summary>
-        </member>
         <member name="T:OBSWebsocketDotNet.Types.SceneItemTransformInfo">
             <summary>
-            Scene transformation information from an event
+            Item transformation information
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.SceneName">
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.Alignnment">
             <summary>
-            Name of the scene
+            Alignment of the item
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.ItemName">
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.BoundsAlignnment">
             <summary>
-            Name of the item in the scene
+            The point on the scene item that the item is manipulated from
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.ItemID">
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.BoundsHeight">
             <summary>
-            Scene Item ID
+            Height of the bounding box
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.Transform">
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.BoundsWidth">
             <summary>
-            Scene item transform properties
+            Width of the bounding box
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.BoundsType">
+            <summary>
+            Type of bounding box
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemTransformInfo.CropBottom">
+            <summary>
+            Bottom crop (in pixels)
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemTransformInfo.CropLeft">
+            <summary>
+            Left crop (in pixels)
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemTransformInfo.CropRight">
+            <summary>
+            Right crop (in pixels)
+            </summary>
+        </member>
+        <member name="F:OBSWebsocketDotNet.Types.SceneItemTransformInfo.CropTop">
+            <summary>
+            Top crop (in pixels)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.Rotation">
+            <summary>
+            The clockwise rotation of the scene item in degrees around the point of alignment.
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.ScaleX">
+            <summary>
+            The x-scale factor of the scene item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.ScaleY">
+            <summary>
+            The y-scale factor of the scene item
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.SourceHeight">
+            <summary>
+            Base height (without scaling) of the source
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.SourceWidth">
+            <summary>
+            Base width (without scaling) of the source
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.Height">
+            <summary>
+            Scene item height (base source height multiplied by the vertical scaling factor)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.Width">
+            <summary>
+            Scene item width (base source width multiplied by the horizontal scaling factor)
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.X">
+            <summary>
+            The x position of the scene item from the left
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.SceneItemTransformInfo.Y">
+            <summary>
+            The y position of the scene item from the top
             </summary>
         </member>
         <member name="M:OBSWebsocketDotNet.Types.SceneItemTransformInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
@@ -2876,80 +5091,30 @@
             Default Constructor for deserialization
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SourceInfo">
+        <member name="T:OBSWebsocketDotNet.Types.SourceActiveInfo">
             <summary>
-            Source information returned by GetSourcesList
+            Gets the Active and Showing state of a video source
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceInfo.Name">
+        <member name="P:OBSWebsocketDotNet.Types.SourceActiveInfo.VideoActive">
             <summary>
-            Name of the source
+            Whether the source is showing in Program
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceInfo.TypeID">
+        <member name="P:OBSWebsocketDotNet.Types.SourceActiveInfo.VideoShowing">
             <summary>
-            Non-unique source internal type(a.k.a type id)
+            Whether the source is showing in the UI (Preview, Projector, Properties)
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceInfo.Type">
+        <member name="M:OBSWebsocketDotNet.Types.SourceActiveInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
-            Source type.Value is one of the following: "input", "filter", "transition", "scene" or "unknown"
+            Auto populate constructor
             </summary>
+            <param name="data"></param>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SourceScreenshotResponse">
+        <member name="M:OBSWebsocketDotNet.Types.SourceActiveInfo.#ctor">
             <summary>
-            Response from <see cref="M:OBSWebsocketDotNet.OBSWebsocket.TakeSourceScreenshot(System.String,System.String,System.String,System.Int32,System.Int32)"/>
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceScreenshotResponse.SourceName">
-            <summary>
-            Source name
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceScreenshotResponse.ImageData">
-            <summary>
-            Image Data URI(if embedPictureFormat was specified in the request)
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceScreenshotResponse.ImageFile">
-            <summary>
-            Absolute path to the saved image file(if saveToFilePath was specified in the request)
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.SourceSettings">
-            <summary>
-            Settings for a source item
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceSettings.SourceName">
-            <summary>
-            Name of the source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceSettings.SourceKind">
-            <summary>
-            Kind of source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceSettings.SourceType">
-            <summary>
-            Type of the specified source. Useful for type-checking if you expect a specific settings schema.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceSettings.Settings">
-            <summary>
-            Settings for the source
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SourceSettings.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Builds the object from the JSON data
-            </summary>
-            <param name="data">JSON item description as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SourceSettings.#ctor">
-            <summary>
-            Default Constructor for deserialization
+            Default Constructor
             </summary>
         </member>
         <member name="T:OBSWebsocketDotNet.Types.SourceTracks">
@@ -2998,112 +5163,6 @@
             Default Constructor for deserialization
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.SourceType">
-            <summary>
-            OBS Source Type definitions
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceType.TypeID">
-            <summary>
-            Non-unique internal source type ID
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceType.DisplayName">
-            <summary>
-            Display name of the source type
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceType.Type">
-            <summary>
-            Type.Value is one of the following: "input", "filter", "transition" or "other"
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceType.DefaultSettings">
-            <summary>
-            Default settings of the source type
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceType.Capabilities">
-            <summary>
-            Source type capabilities
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.SourceTypeCapabilities">
-            <summary>
-            Capabilities for a SourceType
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.IsAsync">
-            <summary>
-            True if source of this type provide frames asynchronously
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.IsDeprecated">
-            <summary>
-            True if source of this type is deprecated
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.HasVideo">
-            <summary>
-            True if sources of this type provide video
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.HasAudio">
-            <summary>
-            True if sources of this type provide audio
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.CanInteract">
-            <summary>
-            True if interaction with this sources of this type is possible
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.IsComposite">
-            <summary>
-            True if sources of this type composite one or more sub-sources
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.DoNotDuplicate">
-            <summary>
-            True if sources of this type should not be fully duplicated
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceTypeCapabilities.DoNotSelfMonitor">
-            <summary>
-            True if sources of this type may cause a feedback loop if it's audio is monitored and shouldn't be
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.SourceVolume">
-            <summary>
-            Source volume values
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceVolume.SourceName">
-            <summary>
-            Name of the source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceVolume.Volume">
-            <summary>
-            The source volume in percent
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.SourceVolume.VolumeDb">
-            <summary>
-            The source volume in decibels
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SourceVolume.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Builds the object from the JSON response body
-            </summary>
-            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.SourceVolume.#ctor">
-            <summary>
-            Empty constructor for jsonconvert
-            </summary>
-        </member>
         <member name="T:OBSWebsocketDotNet.Types.StreamingService">
             <summary>
             Streaming settings
@@ -3149,242 +5208,6 @@
             The password to use when accessing the streaming server. Only present if use-auth is true
             </summary>
         </member>
-        <member name="T:OBSWebsocketDotNet.Types.StreamStatus">
-            <summary>
-            Data of a stream status update
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.Streaming">
-            <summary>
-            True if streaming is started and running, false otherwise
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.Recording">
-            <summary>
-            True if recording is started and running, false otherwise
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.BytesPerSec">
-            <summary>
-            Stream bitrate in bytes per second
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.KbitsPerSec">
-            <summary>
-            Stream bitrate in kilobits per second
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.Strain">
-            <summary>
-            RTMP output strain
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.TotalStreamTime">
-            <summary>
-            Total time since streaming start
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.TotalFrames">
-            <summary>
-            Number of frames sent since streaming start
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.DroppedFrames">
-            <summary>
-            Overall number of frames dropped since streaming start
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.FPS">
-            <summary>
-            Current framerate in Frames Per Second
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.CPU">
-            <summary>
-            Current OBS CPU Usage
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.SkippedFrames">
-            <summary>
-            Total number of skipped frames
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.RenderMissedFrames">
-            <summary>
-            Total number of missed frames
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.StreamTime">
-            <summary>
-            Overall stream time
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.StreamStatus.ReplayBufferActive">
-            <summary>
-            Is replay buffer active
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.StreamStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Builds the object from the JSON event body
-            </summary>
-            <param name="data">JSON event body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.Types.StreamStatus.#ctor">
-            <summary>
-            Default Constructor for deserialization
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.TextGDIPlusFont">
-            <summary>
-            Font information for a Text GDI+ source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusFont.Face">
-            <summary>
-            Font face.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusFont.Flags">
-            <summary>
-            Font text styling flag. Bold=1, Italic=2, Bold Italic=3, Underline=5, Strikeout=8
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusFont.Size">
-            <summary>
-            Font text size.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusFont.Style">
-            <summary>
-            Font Style (unknown function).
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.Types.TextGDIPlusProperties">
-            <summary>
-            Properties for a GDI+ Text source
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.SourceName">
-            <summary>
-            Source name.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.Alignment">
-            <summary>
-            Text Alignment ("left", "center", "right").
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.BackgroundColor">
-            <summary>
-            Background color.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.BackgroundOpacity">
-            <summary>
-            Background opacity (0-100).
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.IsChatLog">
-            <summary>
-            Chat log.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.ChatlogLines">
-            <summary>
-            Chat log lines.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.TextColor">
-            <summary>
-            Text color.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.HasExtents">
-            <summary>
-            Extents wrap.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.Height">
-            <summary>
-            Extents cx.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.Width">
-            <summary>
-            Extents cy.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.Filename">
-            <summary>
-            File path name.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.IsReadFromFile">
-            <summary>
-            Read text from the specified file.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.Font">
-            <summary>
-            Holds data for the font. Ex: "font": { "face": "Arial", "flags": 0, "size": 150, "style": "" }
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.HasGradient">
-            <summary>
-            Gradient enabled.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.GradientColor">
-            <summary>
-            Gradient color.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.GradientDirection">
-            <summary>
-            Gradient direction.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.GradientOpacity">
-            <summary>
-            Gradient opacity (0-100).
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.HasOutline">
-            <summary>
-            Outline.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.OutlineColor">
-            <summary>
-            Outline color.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.OutlineSize">
-            <summary>
-            Outline size.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.OutlineOpacity">
-            <summary>
-            Outline opacity (0-100).
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.Text">
-            <summary>
-            Text content to be displayed.
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.VeritcalAslignment">
-            <summary>
-            Text vertical alignment ("top", "center", "bottom").
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.Types.TextGDIPlusProperties.IsVertical">
-            <summary>
-            Vertical text enabled.
-            </summary>
-        </member>
         <member name="T:OBSWebsocketDotNet.Types.TransitionOverrideInfo">
             <summary>
             Scene transition override settings
@@ -3415,6 +5238,26 @@
             Transition duration in milliseconds
             </summary>
         </member>
+        <member name="P:OBSWebsocketDotNet.Types.TransitionSettings.Kind">
+            <summary>
+            Kind of the transition
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.TransitionSettings.IsFixed">
+            <summary>
+            Whether the transition uses a fixed (unconfigurable) duration
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.TransitionSettings.IsConfigurable">
+            <summary>
+            Whether the transition supports being configured
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.TransitionSettings.Settings">
+            <summary>
+            Object of settings for the transition. 'null' if transition is not configurable
+            </summary>
+        </member>
         <member name="M:OBSWebsocketDotNet.Types.TransitionSettings.#ctor(Newtonsoft.Json.Linq.JObject)">
             <summary>
             Builds the object from the JSON response body
@@ -3426,19 +5269,40 @@
             Default Constructor for deserialization
             </summary>
         </member>
+        <member name="T:OBSWebsocketDotNet.Types.VirtualCamStatus">
+            <summary>
+            VirtualCam Status
+            </summary>
+        </member>
+        <member name="P:OBSWebsocketDotNet.Types.VirtualCamStatus.IsActive">
+            <summary>
+            Whether the output is active
+            </summary>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.VirtualCamStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Builds the object from the JSON response body
+            </summary>
+            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
+        </member>
+        <member name="M:OBSWebsocketDotNet.Types.VirtualCamStatus.#ctor">
+            <summary>
+            Constructor for jsonconverter
+            </summary>
+        </member>
         <member name="T:OBSWebsocketDotNet.Types.VolumeInfo">
             <summary>
             Volume settings of an OBS source
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.VolumeInfo.Volume">
+        <member name="P:OBSWebsocketDotNet.Types.VolumeInfo.VolumeMul">
             <summary>
             Source volume in linear scale (0.0 to 1.0)
             </summary>
         </member>
-        <member name="P:OBSWebsocketDotNet.Types.VolumeInfo.Muted">
+        <member name="P:OBSWebsocketDotNet.Types.VolumeInfo.VolumeDb">
             <summary>
-            True if source is muted, false otherwise
+            Volume setting in dB
             </summary>
         </member>
         <member name="M:OBSWebsocketDotNet.Types.VolumeInfo.#ctor(Newtonsoft.Json.Linq.JObject)">
@@ -3450,32 +5314,6 @@
         <member name="M:OBSWebsocketDotNet.Types.VolumeInfo.#ctor">
             <summary>
             Default Constructor for deserialization
-            </summary>
-        </member>
-        <member name="T:OBSWebsocketDotNet.VirtualCamStatus">
-            <summary>
-            VirtualCam Status
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.VirtualCamStatus.IsActive">
-            <summary>
-            The current virtual camera status
-            </summary>
-        </member>
-        <member name="P:OBSWebsocketDotNet.VirtualCamStatus.Timecode">
-            <summary>
-            Time elapsed since virtual camera started (only present if virtual cam currently active)
-            </summary>
-        </member>
-        <member name="M:OBSWebsocketDotNet.VirtualCamStatus.#ctor(Newtonsoft.Json.Linq.JObject)">
-            <summary>
-            Builds the object from the JSON response body
-            </summary>
-            <param name="data">JSON response body as a <see cref="T:Newtonsoft.Json.Linq.JObject"/></param>
-        </member>
-        <member name="M:OBSWebsocketDotNet.VirtualCamStatus.#ctor">
-            <summary>
-            Constructor for jsonconverter
             </summary>
         </member>
     </members>


### PR DESCRIPTION
This contains a fix for the issues described in #136 

It also contains:
- Fixes for deserialization issues in `MediaInputStatus`
- Actually allowing `OBSVideoSettings` to be updated via the API, by removing `internal` from the setters
- Build enhancements